### PR TITLE
Document the 'Access Denied' For LCM User Issue

### DIFF
--- a/TSG/LCM/access-denied-lcm-user.md
+++ b/TSG/LCM/access-denied-lcm-user.md
@@ -55,7 +55,7 @@ elseif ($ValidateActionPlanInstance.Status -eq 'Completed')
 ```
 
 ### Update the LCM Credentials in the ECE Store
-To update the LCM user credentials in the ECE store. Input your LCM user credentials when prompted.
+To update the LCM user credentials in the ECE store, run the below script. Input your LCM user credentials when prompted.
 ```
 # Prompt for credentials
 $credential = Get-Credential


### PR DESCRIPTION
* Users may face "Access Denied" for the LCM User. Adding documentation for identifying and mitigating the issue.