### PR TITLE
Update mitigation steps to add missing parenthesis and set Credential

### DIFF
--- a/TSG/SolutionExtension/HealthCheck-known-issues/SBE-HealthCheck-content-integrity-failure.md
+++ b/TSG/SolutionExtension/HealthCheck-known-issues/SBE-HealthCheck-content-integrity-failure.md
@@ -94,12 +94,13 @@ Alternatively, for scenario 3, or if you prefer to assure this issue has been re
 ```Powershell
 Invoke-Command -ComputerName (Get-ClusterNode).Name -ScriptBlock {
     $defaultPath = "C:\ClusterStorage\Infrastructure_1\Shares\SU1_Infrastructure_1\CloudMedia\SBE\Installed\metadata"
-    if ($false -eq Test-Path -Path $defaultPath) {
+    if ($false -eq (Test-Path -Path $defaultPath)) {
         $sbeConfigPath = Get-ASArtifactPath -NugetName "Microsoft.AzureStack.SBEConfiguration" 3>$null 4>$null
         $defaultPath = Join-Path -Path $sbeConfigPath -ChildPath "content"
     }
     [System.Environment]::SetEnvironmentVariable("SBEStagedMetadata", $defaultPath, "Machine")
 }
+Write-Host ("Updated 'SBEStagedMetadata' to " + [System.Environment]::GetEnvironmentVariable("SBEStagedMetadata", "Machine"))
 ```
 
 2. Once the script has been run, you can directly call the daily system health check to confirm the issue has been resolved using:

--- a/TSG/SolutionExtension/HealthCheck-known-issues/SBE-HealthCheck-content-integrity-failure.md
+++ b/TSG/SolutionExtension/HealthCheck-known-issues/SBE-HealthCheck-content-integrity-failure.md
@@ -89,10 +89,11 @@ If you have confirmed this issue is only observed in the system health check (sc
 
 Alternatively, for scenario 3, or if you prefer to assure this issue has been resolved before proceeding with the update, you can use the following steps to correct the bad environment variable value.
 
-1. Run the script below on any cluster node to reset the environment variable to the default value on all nodes:
+1. Run the script below on any cluster node to reset the environment variable to the default value on all nodes. Specify the normal AD deployment user (the LCM user as prompted during the cloud deployment process).
 
 ```Powershell
-Invoke-Command -ComputerName (Get-ClusterNode).Name -ScriptBlock {
+$cred = Get-Credential
+Invoke-Command -Credential $cred -ComputerName (Get-ClusterNode).Name -ScriptBlock {
     $defaultPath = "C:\ClusterStorage\Infrastructure_1\Shares\SU1_Infrastructure_1\CloudMedia\SBE\Installed\metadata"
     if ($false -eq (Test-Path -Path $defaultPath)) {
         $sbeConfigPath = Get-ASArtifactPath -NugetName "Microsoft.AzureStack.SBEConfiguration" 3>$null 4>$null


### PR DESCRIPTION
Unless user is connected to the node via RDP or remote console session they will likely need to provide `-Credential` value for the Invoke-Command in the mitigation script to work.