### PR TITLE
Update 23H2-Deployment-Failure-at-Validation-task-of-Azure-Stack-HCI-…

### DIFF
--- a/TSG/Deployment/23H2-Deployment-Failure-at-Validation-task-of-Azure-Stack-HCI-Hardware.md
+++ b/TSG/Deployment/23H2-Deployment-Failure-at-Validation-task-of-Azure-Stack-HCI-Hardware.md
@@ -60,4 +60,4 @@ On each node where the issue is hit, follow below steps:
 
 3. Restart the node.
 
-4. In the Azure Portal, retry the failed validation by clicking "Try Again" button in the deploy blade.
+4. In the Azure Portal, retry the failed validation by clicking "Try Again" button in the deploy blade, or start the validation again if there is no "Try Again" option.


### PR DESCRIPTION
…Hardware.md

when customers use template-based deployment, there is no retry. So fix the wording of mitigation step.