### PR TITLE
Fix New-Object line in pending GetGauDeviceInfo TSG

### DIFF
--- a/TSG/Update/Solution-update-get-hung-at-downloading-status-with-action-plan-instance-running-for-months .md
+++ b/TSG/Update/Solution-update-get-hung-at-downloading-status-with-action-plan-instance-running-for-months .md
@@ -34,7 +34,7 @@ $actionPlanInstanceID = "<ActionPlan Instance ID>"
 Cancel-ActionPlanInstance -eceClient $eceClient -actionPlanInstanceID $actionPlanInstanceID
 
 # remove old instance
-$deleteActionPlanInstanceDescription = New-Object -TypeName 'GetCauDeviceInfo'
+$deleteActionPlanInstanceDescription = New-Object Microsoft.AzureStack.Solution.Deploy.EnterpriseCloudEngine.Controllers.Models.DeleteActionPlanInstanceDescription
 $deleteActionPlanInstanceDescription.ActionPlanInstanceID = $actionPlanInstanceID
 $eceClient.DeleteActionPlanInstance($deleteActionPlanInstanceDescription).Wait()
 ```


### PR DESCRIPTION
There is error when using `New-Object -TypeName 'GetCauDeviceInfo'`
![image](https://github.com/user-attachments/assets/b85883f8-590d-49c7-b1da-febb21e54949)

Solution is to use `New-Object Microsoft.AzureStack.Solution.Deploy.EnterpriseCloudEngine.Controllers.Models.DeleteActionPlanInstanceDescription`

This fix was used and verified in https://portal.microsofticm.com/imp/v5/incidents/details/565428533/summary