### PR TITLE
updated to remove , on line 200 as error At line:17 char:43

### DIFF
--- a/TSG/Update/Update-Hangs-after-Secret-Rotation.md
+++ b/TSG/Update/Update-Hangs-after-Secret-Rotation.md
@@ -197,7 +197,7 @@ Function Restart-AzureLocalServices {
         $services = @(
             'Azure Stack HCI Download Standalone Tool Agent',
             'ECEAgent',
-            'URP Windows Service Service',
+            'URP Windows Service Service'
             )
         return;
     }


### PR DESCRIPTION
At line:17 char:43
+             'URP Windows Service Service',
+                                           ~
Missing expression after ','.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : MissingExpressionAfterToken

updated script to remove , after 'URP Windows Service Service',