### PR TITLE
TSG for error "Could not update IgvmAgent"

### DIFF
--- a/TSG/ArcVMs/cannot-update-IgvmAgent.md
+++ b/TSG/ArcVMs/cannot-update-IgvmAgent.md
@@ -21,6 +21,10 @@ This occurs because there is an underlying issue with removing certain folders. 
 For customers updating their Azure Local instance to 2505 release, if you encounter any of the above errors, perform the following steps to resolve the issue:
 
 1. [Required] Restart Azure Local instance (all the machines in your Azure Local instance).
-2. [Required] Resume Azure Local update (repeat steps to update your Azure Local instance).
+2.1 Log in into one of the nodes instances and open a Powershell admin console.
+2.2 Create an ECE Cluster service by running: ```$ececlient = Create-EceClusterServiceClient```
+2.3 Run update action plan for IGVM Agent by running: ```$guid = Invoke-ActionPlanInstance -RolePath IgvmAgentDeployment  -ActionType DeployIgvmAgent -EceClient:$ececlient```
+2.4 Monitor the action plan until it succeeds by running: ```Start-MonitoringActionplanInstanceToComplete $guid```
+3. [Required] Resume Azure Local update (repeat steps to update your Azure Local instance).
 
 Alternately, you can skip 2505 and directly update your Azure Local instance to 2506 release or above to resolve the issue.

--- a/TSG/ArcVMs/cannot-update-IgvmAgent.md
+++ b/TSG/ArcVMs/cannot-update-IgvmAgent.md
@@ -24,7 +24,7 @@ For customers updating their Azure Local instance to 2505 release, if you encoun
 2. [Optional] Run IGVM Agent update plan.
    - Log in into one of the nodes instances and open a Powershell admin console.
    - Create an ECE Cluster service by running: ```$ececlient = Create-EceClusterServiceClient```
-   - Run update action plan for IGVM Agent by running: ```$guid = Invoke-ActionPlanInstance -RolePath IgvmAgentDeployment  -ActionType DeployIgvmAgent -EceClient:$ececlient```
+   - Run update action plan for IGVM Agent by running: ```$guid = Invoke-ActionPlanInstance -RolePath IgvmAgentDeployment -ActionType DeployIgvmAgent -EceClient:$ececlient```
    - Monitor the action plan until it succeeds by running: ```Start-MonitoringActionplanInstanceToComplete $guid```
 3. [Required] Resume Azure Local update (repeat steps to update your Azure Local instance).
 

--- a/TSG/ArcVMs/cannot-update-IgvmAgent.md
+++ b/TSG/ArcVMs/cannot-update-IgvmAgent.md
@@ -22,10 +22,10 @@ For customers updating their Azure Local instance to 2505 release, if you encoun
 
 1. [Required] Restart Azure Local instance (all the machines in your Azure Local instance).
 2. [Optional] Run IGVM Agent update plan.
-2.1 Log in into one of the nodes instances and open a Powershell admin console.
-2.2 Create an ECE Cluster service by running: ```$ececlient = Create-EceClusterServiceClient```
-2.3 Run update action plan for IGVM Agent by running: ```$guid = Invoke-ActionPlanInstance -RolePath IgvmAgentDeployment  -ActionType DeployIgvmAgent -EceClient:$ececlient```
-2.4 Monitor the action plan until it succeeds by running: ```Start-MonitoringActionplanInstanceToComplete $guid```
+   - Log in into one of the nodes instances and open a Powershell admin console.
+   - Create an ECE Cluster service by running: ```$ececlient = Create-EceClusterServiceClient```
+   - Run update action plan for IGVM Agent by running: ```$guid = Invoke-ActionPlanInstance -RolePath IgvmAgentDeployment  -ActionType DeployIgvmAgent -EceClient:$ececlient```
+   - Monitor the action plan until it succeeds by running: ```Start-MonitoringActionplanInstanceToComplete $guid```
 3. [Required] Resume Azure Local update (repeat steps to update your Azure Local instance).
 
 Alternately, you can skip 2505 and directly update your Azure Local instance to 2506 release or above to resolve the issue.

--- a/TSG/ArcVMs/cannot-update-IgvmAgent.md
+++ b/TSG/ArcVMs/cannot-update-IgvmAgent.md
@@ -21,6 +21,7 @@ This occurs because there is an underlying issue with removing certain folders. 
 For customers updating their Azure Local instance to 2505 release, if you encounter any of the above errors, perform the following steps to resolve the issue:
 
 1. [Required] Restart Azure Local instance (all the machines in your Azure Local instance).
+2. [Optional] Run IGVM Agent update plan.
 2.1 Log in into one of the nodes instances and open a Powershell admin console.
 2.2 Create an ECE Cluster service by running: ```$ececlient = Create-EceClusterServiceClient```
 2.3 Run update action plan for IGVM Agent by running: ```$guid = Invoke-ActionPlanInstance -RolePath IgvmAgentDeployment  -ActionType DeployIgvmAgent -EceClient:$ececlient```

--- a/TSG/ArcVMs/cannot-update-IgvmAgent.md
+++ b/TSG/ArcVMs/cannot-update-IgvmAgent.md
@@ -1,0 +1,26 @@
+# Symptoms    
+When updating your Azure Local instance to 2506 release, you encounter one of the following errors:
+
+```
+Could not update IgvmAgent on physical node Exception: Unable to create a new version folder with in 10 tries.
+```
+```
+Could not update IgvmAgent on physical node Exception: Cannot remove item C:\CloudContent\IgvmAgent\_v2\AszIgvmAgent.exe: Access to the path ‘C:\CloudContent\IgvmAgent_v2\AszIgvmAgent.exe’ is denied.
+```
+Note, in the sample error message, _v2 refers to a version 2, which in practice can be v*, * range between 1 and 9.
+
+# Issue Validation
+      
+Ensure the error message you notice matches one of the above error messages.
+
+# Cause
+This occurs because there is an underlying issue with removing certain folders. We have fixed this in 2506 release.
+
+# Mitigation Details
+
+For customers updating their Azure Local instance to 2505 release, if you encounter any of the above errors, perform the following steps to resolve the issue:
+
+1. [Required] Restart Azure Local instance (all the machines in your Azure Local instance).
+2. [Required] Resume Azure Local update (repeat steps to update your Azure Local instance).
+
+Alternately, you can skip 2505 and directly update your Azure Local instance to 2506 release or above to resolve the issue.


### PR DESCRIPTION
This TSG provides mitigation steps to address IgvmAgent error "Could not update IgvmAgent" which can happen when customers update their Azure Local instance. While this issue is addressed in 2506 release, this TSG provides mitigation steps customers can take to address this error if it happens while updating their Azure Local instance to a release earlier than 2506, for instance, while updating an Azure Local instance from 2503 to 2504.