### PR TITLE
Focus CoPilot review on state changing commands

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -86,8 +86,8 @@ When reviewing or suggesting PowerShell code in documentation:
   - Check for proper error handling.
   - Use placeholders like <hostname> instead of hardcoded values.
 
-```powershell
 Example:
+```powershell
 # DANGEROUS EXAMPLE - Could cause an unexpected state
 Restart-Service -Name "CriticalService" -Force
 
@@ -101,6 +101,13 @@ if ($confirmation -eq 'y') {
     Write-Host "Restarting $serviceName..."
     Restart-Service -Name $serviceName
 }
+```
+
+Example:
+```powershell
+# Explictely set ErrorActionPreference
+$ErrorActionPreference = "Stop"
+Get-Service -Name "NonExistentService"
 ```
 
 ## Link Guidelines

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -77,12 +77,14 @@ Format each review comment with:
 
 ## PowerShell Code Guidelines
 When reviewing or suggesting PowerShell code in documentation:
-- Verify code is safe for production environments
-- Implement defensive coding techniques (check conditions before taking action)
-- Include verification steps before and after changes
-- Ensure commands don't disrupt workloads
-- Check for proper error handling
-- Use placeholders like <hostname> instead of hardcoded values
+- Pay special attention to commands that change environment state (e.g., restart, stop, remove, set, write).
+- For state-changing commands:
+  - Verify code is safe for production environments.
+  - Implement defensive coding techniques (check conditions before taking action).
+  - Include verification steps before and after changes.
+  - Ensure commands don't disrupt workloads.
+  - Check for proper error handling.
+  - Use placeholders like <hostname> instead of hardcoded values.
 
 ```powershell
 Example:


### PR DESCRIPTION
This minor change should help CoPilot focus state changing cmdlets when reviewing PS Code

Here is an example PR where CoPilot missed that the ErrorActionPreference for a script was set
https://github.com/Azure/AzureLocal-Supportability/pull/164/files/76a8d9298f9f2ea358d9b43d4b69b15ac723d9f2#diff-2dfb057298a2498af23aad06db5ec09d59e2fceac297f931d24c8876cad99ad9