### PR TITLE
Fix XML loading syntax for update progress

### DIFF
--- a/TSG/Update/Manually-retry-after-failed-at-CauPostVersionCheck.md
+++ b/TSG/Update/Manually-retry-after-failed-at-CauPostVersionCheck.md
@@ -41,7 +41,7 @@ Below is a simplified **PowerShell script** that will automate the steps necessa
    Write-Host "Found action plan $($update.InstanceID) for update version $($update.RuntimeParameters.UpdateVersion)."
    
    # Load XML and locate 'Update Host OS' step
-   $xml = $update.ProgressAsXml
+   [xml]$xml = $update.ProgressAsXml
    $updateHostStep = $xml.SelectSingleNode("//Step[@Name='Update Host OS']")
    if (-not $updateHostStep) {
        throw "Cannot find 'Update Host OS' step in the action plan."


### PR DESCRIPTION
This needs to be forced as XML type otherwise it will error out as method invocation failed because [System.String] does not contain a method named 'SelectSingleNode'