### PR TITLE
[Network] Add TSGs for Environment Validator InboxDriver, Driver Consistency, and ManagementAdapterReadiness checks

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,19 +70,21 @@ Format each review comment with:
 - [ ] Default values clearly indicated
 
 ## Language Assistance Guidelines
-- Suggest corrections for spelling and grammar in a supportive manner
-- Frame language suggestions as "improvements" rather than "corrections"
-- Focus on clarity rather than perfect English
-- Prioritize technical accuracy over language perfection
+When reviewing or suggesting language improvements (in order of importance):
+1. Focus on clarity rather than perfect English
+2. Prioritize technical accuracy over language perfection
+3. Suggest corrections for spelling
+
+Frame language suggestions as "improvements" rather than "corrections"
 
 ## PowerShell Code Guidelines
 When reviewing or suggesting PowerShell code in documentation:
 - Pay special attention to commands that change environment state (e.g., restart, stop, remove, set, write).
 - For state-changing commands:
   - Verify code is safe for production environments.
-  - Implement defensive coding techniques (check conditions before taking action).
+  - Implement defensive coding techniques (check conditions before taking action). But avoid excessive complexity.
   - Include verification steps before and after changes.
-  - Ensure commands don't disrupt workloads.
+  - Ensure commands don't disrupt workloads. If they do, provide clear warnings.
   - Check for proper error handling.
   - Use placeholders like <hostname> instead of hardcoded values.
 
@@ -91,16 +93,8 @@ Example:
 # DANGEROUS EXAMPLE - Could cause an unexpected state
 Restart-Service -Name "CriticalService" -Force
 
-# SAFER ALTERNATIVE - Checks status and confirm before action
-$serviceName = "CriticalService"
-$service = Get-Service -Name $serviceName
-Write-Host "Current status of $serviceName is: $($service.Status)"
-
-$confirmation = Read-Host "Are you sure you want to restart $serviceName? (y/n)"
-if ($confirmation -eq 'y') {
-    Write-Host "Restarting $serviceName..."
-    Restart-Service -Name $serviceName
-}
+# SAFER ALTERNATIVE - Don't use force
+Restart-Service -Name "CriticalService"
 ```
 
 Example:

--- a/TSG/EnvironmentValidator/Networking/CONTRIBUTING.md
+++ b/TSG/EnvironmentValidator/Networking/CONTRIBUTING.md
@@ -85,6 +85,8 @@ Here is an example:
 }
 ```
 
+---
+
 ### Failure: !!FAILURE_MESSAGE - Put any failure messages from the Detail section here, if there are multiple possible messages, split them into different sections
 
 !!FAILURE_MESSAGE_DESCRIPTION - Put a description of the failure message here. How should it be interpreted?

--- a/TSG/EnvironmentValidator/Networking/README.md
+++ b/TSG/EnvironmentValidator/Networking/README.md
@@ -11,6 +11,7 @@ For Azure Local Network Resources not related to Environment Validator, see [TSG
 - [Troubleshoot: Storage Connections VMSwitch Configuration](Troubleshoot-Network-Test-StorageConnections-VMSwitch-Configuration.md)
 - [Troubleshoot: Network Adapter Inbox Driver Check](Troubleshoot-Network-Test-NetworkAdapter-InboxDriver.md)
 - [Troubleshoot: Network Adapter Driver Consistency Check](Troubleshoot-Network-Test-NetworkAdapter-DriverConsistency.md)
+- [Troubleshoot: Management Adapter Readiness](Troubleshoot-Network-Test-ManagementAdapterReadiness.md)
 
 ---
 

--- a/TSG/EnvironmentValidator/Networking/README.md
+++ b/TSG/EnvironmentValidator/Networking/README.md
@@ -9,6 +9,8 @@ For Azure Local Network Resources not related to Environment Validator, see [TSG
 - [Troubleshoot: Storage Connections Connectivity Check](Troubleshoot-Network-Test-StorageConnections-ConnectivityCheck.md)
 - [Troubleshoot: Storage Connections No Validation Method](Troubleshoot-Network-Test-StorageConnections-NoValidationMethod.md)
 - [Troubleshoot: Storage Connections VMSwitch Configuration](Troubleshoot-Network-Test-StorageConnections-VMSwitch-Configuration.md)
+- [Troubleshoot: Network Adapter Inbox Driver Check](Troubleshoot-Network-Test-NetworkAdapter-InboxDriver.md)
+- [Troubleshoot: Network Adapter Driver Consistency Check](Troubleshoot-Network-Test-NetworkAdapter-DriverConsistency.md)
 
 ---
 

--- a/TSG/EnvironmentValidator/Networking/Troubleshoot-Network-Test-ManagementAdapterReadiness.md
+++ b/TSG/EnvironmentValidator/Networking/Troubleshoot-Network-Test-ManagementAdapterReadiness.md
@@ -1,0 +1,192 @@
+# AzureLocal_Network_Test_ManagementAdapterReadines
+<table border="1" cellpadding="6" cellspacing="0" style="border-collapse:collapse; margin-bottom:1em;">
+  <tr>
+    <th style="text-align:left; width: 180px;">Name</th>
+    <td><strong>AzureLocal_Network_Test_ManagementAdapterReadines</strong></td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 180px;">Severity</th>
+    <td><strong>Critical</strong>: This validator will block operations until remediated.</td>
+  </tr>
+  <tr>
+    <th style="text-align:left;">Applicable Scenarios</th>
+    <td><strong>Deployment</strong></td>
+  </tr>
+</table>
+
+## Overview
+
+This validator fails if the management adapters (the adapters assigned to the Management Network Intent) are not configured properly. The management adapter must have a valid IP address configured so that the node can communicate with other nodes during the deployment process.
+
+## Requirements
+
+At least one adapter assigned to the Management Network Intent must meet the following requirements:
+1. Have a valid IP Configuration
+2. Have a valid default gateway configured
+3. Have a valid DNS server configured
+4. If this is a DHCP deployment, the adapter must be configured to use DHCP, otherwise it must have a static IP configuration.
+
+If any manaagement adapter is part of a VM Switch then the following requirement also applies:
+1. All management adapters must be part of the VM Switch
+2. A management adapter named `vManagement(intentName)` must exist and meet the requirements above.
+
+See [Azure Local - Host Network Requirements](https://docs.azure.cn/en-us/azure-local/concepts/host-network-requirements#driver-requirements) for more details.
+
+## Troubleshooting Steps
+
+### Review Environment Validator Output
+
+Review the Environment Validator output JSON. Check the `AdditionalData.Detail` field for summary of which Management Adapters are not configured properly. You can identify the host by the `TargetResourceID` field, the format is `NodeName`.
+
+Note that this validator may report multiple failures in the `Detail` field. Each failure is numbered and described below.
+
+```json
+{
+    "Name":  "AzureLocal_Network_Test_ManagementAdapterReadiness",
+    "DisplayName":  "Validate that at least one Management Adapter has a valid IP Configuration, DNS Server, and Gateway",
+    "Tags":  {},
+    "Title":  "Validate that at least one Management Adapter has a valid IP Configuration, DNS Server, and Gateway",
+    "Status":  1,
+    "Severity":  2,
+    "Description":  "Each node must have a management adapter with a valid IP Configuration, DNS Server, and Gateway. If this is a DHCP deployment, the management adapter must have a DHCP address. If the adapter is teamed with a VMSwitch, that VMSwitch must have all adapters defined in the management intent and no others.",
+    "Remediation":  "https://aka.ms/azurelocal/envvalidator/ManagementAdapterReadiness",
+    "TargetResourceID":  "AZLOC-NODE1",
+    "TargetResourceName":  "AZLOC-NODE1",
+    "TargetResourceType":  "ManagementAdapter",
+    "Timestamp":  "\/Date(1758302302961)\/",
+    "AdditionalData":  {
+                            "Detail":  "1) [PASS] Adapter [non existent adapter] does not have any IPs configured with expected PrefixOrigin [Manual] or unexpected PrefixOrigin [Dhcp], Adapter [ethernet 2] does not have any IPs configured with expected PrefixOrigin [Manual] or unexpected PrefixOrigin [Dhcp]. 2) [FAIL] First management adapter [non existent adapter] does not have an IP Configuration, at least one IP Configuration is expected. 3) [FAIL] First management adapter [non existent adapter] has [0] DNS Client Servers configured, but expected [1+].",
+                            "Status":  "FAILURE",
+                            "TimeStamp":  "09/19/2025 17:18:22",
+                            "Resource":  "ManagementAdapter",
+                            "Source":  "AZLOC-NODE1"
+                        },
+    "HealthCheckSource":  "Manual\\Standard\\Medium\\Network\\c9897dea"
+}
+```
+
+---
+
+### Failure: `[FAIL] Adapter [AdapterName] has invalid IP(s): [ip 1] with PrefixOrigin [Dhcp], Adapter [AdapterName 2] has valid IP(s): [ip 2] with PrefixOrigin [Manual].`
+
+**Error Message:**
+```text
+[FAIL] Adapter [AdapterName] has invalid IP(s): [ip 1] with PrefixOrigin [Dhcp], Adapter [AdapterName 2] has valid IP(s): [ip 2] with PrefixOrigin [Manual].
+```
+
+**Root Cause:** One of the management adpaters listed does not have a valid IP configuration. If this is a DHCP deployment, the prefix origin must be `Dhcp`. Otherwise, the prefix origin must be `Manual`.
+
+#### Remediation Steps
+
+1) Check the IP configuration of the management adapters
+
+  ```powershell
+  Get-NetAdapter -Name "ethernet","ethernet 2" | Get-NetIPConfiguration
+  ```
+
+2) If this is a DHCP deployment, ensure that both Network Adapters are configured to use DHCP. If this is a static IP deployment, ensure that at least one of the Network Adapters has a valid static IP configuration.
+
+### Failure: `[FAIL] First management adapter [AdapterName] does not have an IP Configuration, at least one IP Configuration is expected.`
+
+**Error Message:**
+```text
+[FAIL] First management adapter [AdapterName] does not have an IP Configuration, at least one IP Configuration is expected.
+```
+
+**Root Cause:** The first management adapter supplied must have a valid IP Configuration. This IP address will be used for communication between nodes during deployment.
+
+#### Remediation Steps
+
+1) Check that the adapter exists
+
+  ```powershell
+  Get-NetAdapter -Name "AdapterName"
+  ```
+
+2) Create an IP Configuration on the adapter, refer to [Configure the Operating System using sconfig](https://learn.microsoft.com/en-us/azure/azure-local/deploy/deployment-install-os?#configure-the-operating-system-using-sconfig) for more details.
+
+  ```powershell
+  # Example for static IP configuration
+  $AdapterName = "AdapterName"
+  $IPAddress = "IP_Address"
+  $PrefixLength = "Prefix_Length"
+  $DefaultGateway = "Default_Gateway"
+  $DNSServers = @("DNS_Server1") # IMPORTANT! Azure Local does not support modifying DNS Server settings post-deployment.
+  
+  Get-NetAdapter -Name $AdapterName
+
+  New-NetIPAddress -InterfaceAlias "AdapterName" -IPAddress $IPAddress -PrefixLength $PrefixLength -DefaultGateway $DefaultGateway
+  Set-DnsClientServerAddress -InterfaceAlias "AdapterName" -ServerAddresses $DNSServers
+  ```
+
+### Failure: `[FAIL] First management adapter [AdapterName] has [0] DNS Client Servers configured, but expected [1+].`
+
+**Error Message:**
+```text
+[FAIL] First management adapter [AdapterName] has [0] DNS Client Servers configured, but expected [1+].
+```
+
+**Root Cause:** The first management adapter must have at least one DNS server configured.
+
+<div style="border-left: 4px solid #28a745; padding: 15px; margin: 20px 0; background: rgba(40, 167, 69, 0.1); border-radius: 6px;">
+  <strong>⚠️ Important:</strong> Azure Local does not support modifying the DNS Server settings post-deployment. See <a href="https://learn.microsoft.com/en-us/azure/azure-local/plan/cloud-deployment-network-considerations?#dns-server-considerations">DNS Server Considerations</a>
+</div>
+
+#### Remediation Steps
+
+1) Check the DNS configuration of the management adapter
+
+  ```powershell
+  Get-NetAdapter -Name "AdapterName" | Get-DnsClientServerAddress
+  ```
+
+2) Configure at least one DNS server on the adapter
+
+  ```powershell
+  Set-DnsClientServerAddress -InterfaceAlias "AdapterName" -ServerAddresses @("DNS_Server1")
+  ```
+
+---
+
+<div
+  style="border-left: 4px solid #0366d6; padding: 15px; margin: 20px 0; background: rgba(3, 102, 214, 0.1); border-radius: 6px;"
+>
+  <strong>📘 Note:</strong> The VMSwitch requirements below only apply to clusters where the Virtual Switch needs to be created before deployment. This is optional and will not apply to most clusters. For more details, see  <a href="https://learn.microsoft.com/en-us/azure/azure-local/plan/cloud-deployment-network-considerations?#2-configure-management-virtual-network-adapter-using-required-network-atc-naming-convention-for-all-nodes">Management VLAN ID with a virtual switch</a>
+</div>
+
+### [FAIL] VMSwitch [ManagementSwitch] uses physical adapter [AdapterGuid] defined in the management intent, but it does not use all physical adapters defined in the management intent.
+
+**Error Message:**
+```text
+[FAIL] VMSwitch [ManagementSwitch] uses physical adapter [AdapterGuid] defined in the management intent, but it does not use all physical adapters defined in the management intent.
+```
+
+**Root Cause:** If a VM Switch has a management adapter assigned to it, then all management adapters must be part of the VM Switch. This is an **OPTIONAL** requirement and may not apply to your deployment. For more details, see [Management VLAN ID with a Virtual Switch](https://learn.microsoft.com/en-us/azure/azure-local/plan/cloud-deployment-network-considerations?#management-vlan-id-with-a-virtual-switch)
+
+#### Remediation Steps
+
+1) Check the VM Switch configuration
+
+  ```powershell
+  Get-VMSwitch "ManagementSwitch" | Select-Object -ExpandProperty NetAdapterInterfaceGuid
+  Get-NetAdapter | Select-Object Name, InterfaceGuid
+  ```
+
+2) Ensure that all management adapters are part of the VM Switch. If not, add the missing adapters to the VM Switch.
+
+  ```powershell
+  Add-VMSwitchTeamMember -SwitchName "ManagementSwitch" -NetAdapterName "AdapterName"
+  ```
+
+### [FAIL] Found VMSwitch [ManagementSwitch] that uses all physical adapters defined in the management intent. Expected 1 VMNetworkAdapter [vManagement(ManagementIntentName)] but found 0. Found 1 NetAdapter [vManagement(ManagementIntentName)] configured.
+
+**Error Message:**
+```text
+[FAIL] Found VMSwitch [ManagementSwitch] that uses all physical adapters defined in the management intent. Expected 1 VMNetworkAdapter [vManagement(ManagementIntentName)] but found 0. Found 1 NetAdapter [vManagement(ManagementIntentName)] configured.
+```
+
+**Root Cause:** If a VM Switch with both management adapters is defined, then a virtual management adapter named `vManagement(ManagementIntentName)` must exist and be configured properly. This `vManagement(ManagementIntentName)` adapter will be used for management traffic. For more details on configuring this adapter see [Configure management virtual network adapter using required Network ATC naming convention for all nodes](https://learn.microsoft.com/en-us/azure/azure-local/plan/cloud-deployment-network-considerations?#2-configure-management-virtual-network-adapter-using-required-network-atc-naming-convention-for-all-nodes)
+
+#### Remediation Steps
+
+See [Configure management virtual network adapter using required Network ATC naming convention for all nodes](https://learn.microsoft.com/en-us/azure/azure-local/plan/cloud-deployment-network-considerations?#2-configure-management-virtual-network-adapter-using-required-network-atc-naming-convention-for-all-nodes) for more details.

--- a/TSG/EnvironmentValidator/Networking/Troubleshoot-Network-Test-ManagementAdapterReadiness.md
+++ b/TSG/EnvironmentValidator/Networking/Troubleshoot-Network-Test-ManagementAdapterReadiness.md
@@ -26,7 +26,7 @@ At least one adapter assigned to the Management Network Intent must meet the fol
 3. Have a valid DNS server configured
 4. If this is a DHCP deployment, the adapter must be configured to use DHCP, otherwise it must have a static IP configuration.
 
-If any manaagement adapter is part of a VM Switch then the following requirement also applies:
+If any management adapter is part of a VM Switch then the following requirement also applies:
 1. All management adapters must be part of the VM Switch
 2. A management adapter named `vManagement(intentName)` must exist and meet the requirements above.
 
@@ -74,7 +74,7 @@ Note that this validator may report multiple failures in the `Detail` field. Eac
 [FAIL] Adapter [AdapterName] has invalid IP(s): [ip 1] with PrefixOrigin [Dhcp], Adapter [AdapterName 2] has valid IP(s): [ip 2] with PrefixOrigin [Manual].
 ```
 
-**Root Cause:** One of the management adpaters listed does not have a valid IP configuration. If this is a DHCP deployment, the prefix origin must be `Dhcp`. Otherwise, the prefix origin must be `Manual`.
+**Root Cause:** One of the management adapters listed does not have a valid IP configuration. If this is a DHCP deployment, the prefix origin must be `Dhcp`. Otherwise, the prefix origin must be `Manual`.
 
 #### Remediation Steps
 

--- a/TSG/EnvironmentValidator/Networking/Troubleshoot-Network-Test-ManagementAdapterReadiness.md
+++ b/TSG/EnvironmentValidator/Networking/Troubleshoot-Network-Test-ManagementAdapterReadiness.md
@@ -1,8 +1,8 @@
-# AzureLocal_Network_Test_ManagementAdapterReadines
+# AzureLocal_Network_Test_ManagementAdapterReadiness
 <table border="1" cellpadding="6" cellspacing="0" style="border-collapse:collapse; margin-bottom:1em;">
   <tr>
     <th style="text-align:left; width: 180px;">Name</th>
-    <td><strong>AzureLocal_Network_Test_ManagementAdapterReadines</strong></td>
+    <td><strong>AzureLocal_Network_Test_ManagementAdapterReadiness</strong></td>
   </tr>
   <tr>
     <th style="text-align:left; width: 180px;">Severity</th>

--- a/TSG/EnvironmentValidator/Networking/Troubleshoot-Network-Test-NetworkAdapter-DriverConsistency.md
+++ b/TSG/EnvironmentValidator/Networking/Troubleshoot-Network-Test-NetworkAdapter-DriverConsistency.md
@@ -1,0 +1,95 @@
+# AzureLocal_Network_Test_NetworkAdapter_DriverConsistency
+<table border="1" cellpadding="6" cellspacing="0" style="border-collapse:collapse; margin-bottom:1em;">
+  <tr>
+    <th style="text-align:left; width: 180px;">Name</th>
+    <td><strong>AzureLocal_Network_Test_NetworkAdapter_DriverConsistency</strong></td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 180px;">Severity</th>
+    <td><strong>Critical</strong>: This validator will block operations until remediated.</td>
+  </tr>
+  <tr>
+    <th style="text-align:left;">Applicable Scenarios</th>
+    <td><strong>Deployment</strong></td>
+  </tr>
+</table>
+
+## Overview
+
+This validator fails if the network adapters that are part of a Network Intent do not use consistent driver versions across all nodes. 
+
+All nodes in the cluster must maintain this consistency to ensure predictable networking behavior.
+
+## Requirements
+
+Adapters that are part of any one Network Intent must meet the following requirements:
+1. Must exist on the system
+2. Must use the same driver version across all nodes in the cluster
+
+See [Azure Local - Host Network Requirements](https://docs.azure.cn/en-us/azure-local/concepts/host-network-requirements#driver-requirements) for more details.
+
+## Troubleshooting Steps
+
+### Review Environment Validator Output
+
+Review the Environment Validator output JSON. Check the `AdditionalData.Detail` field for summary of which Host's Network Adapters are not configured properly. You can identify the host by the `TargetResourceID` field, the format is `NodeName`.
+
+```json
+{
+    "Name":  "AzureLocal_Network_Test_NetworkAdapter_DriverConsistency",
+    "DisplayName":  "Validate that Network Intent Adapters use consistent driver versions across all nodes",
+    "Tags":  {},
+    "Title":  "Validate that Network Intent Adapters use consistent driver versions across all nodes",
+    "Status":  0,
+    "Severity":  2,
+    "Description":  "All Network Adapters assigned to a Network Intent must use consistent driver versions across all nodes. Adapters from the same manufacturer should have identical driver versions. All nodes in the cluster must maintain this consistency to ensure predictable networking behavior.",
+    "Remediation":  "https://aka.ms/azurelocal/envvalidator/IntentAdapterDrivers",
+    "TargetResourceID":  "ManagementCompute Intent",
+    "TargetResourceName":  "ManagementCompute Intent",
+    "TargetResourceType":  "Network Intent Adapters",
+    "Timestamp":  "\/Date(1758143304641)\/",
+    "AdditionalData":  {
+                            "Detail":  "[FAIL] ManagementCompute Intent uses multiple driver versions: [Driver Date 2024-04-16 Version 24.4.26429.0 NDIS 6.89] (AZLOC-NODE1/ethernet, pester-host2/ethernet), [Driver Date 2024-04-16 Version 23.10.26252.0 NDIS 6.89] (AZLOC-NODE1/ethernet 2, pester-host2/ethernet 2).",
+                            "Status":  "FAILURE",
+                            "TimeStamp":  "09/17/2025 21:08:24",
+                            "Resource":  "ManagementCompute Intent",
+                            "Source":  "AZLOC-NODE1"
+                        },
+    "HealthCheckSource":  "Manual\\Standard\\Medium\\Network\\9880e803"
+}
+```
+
+---
+
+### Failure: `[FAIL] IntentName uses multiple driver versions: [Driver Date YYYY-MM-DD Version X.X.XXXXX.X NDIS X.XX] (NodeName/AdapterName, ...), [Driver Date YYYY-MM-DD Version X.X.XXXXX.X NDIS X.XX] (NodeName/AdapterName, ...).`
+
+**Error Message:**
+```text
+[FAIL] ManagementCompute Intent uses multiple driver versions: [Driver Date 2024-04-16 Version 24.4.26429.0 NDIS 6.89] (AZLOC-NODE1/ethernet, pester-host2/ethernet), [Driver Date 2024-04-16 Version 23.10.26252.0 NDIS 6.89] (AZLOC-NODE1/ethernet 2, pester-host2/ethernet 2).
+```
+
+**Root Cause:** The network adapters within the specified Network Intent are using multiple different driver versions across the nodes, which can lead to inconsistent networking behavior.
+
+#### Remediation Steps
+
+1) Check with your hardware vendor to obtain the appropriate drivers for the Network Adapters.
+2) Update the drivers on each Network Adapter in the Network Intent to ensure they all use the same version across all nodes in the cluster. Note that the adapter's in each Network Intent must use the same driver across all nodes.
+
+### Failure: `[FAIL] IntentName uses multiple driver versions: [Adapter Not Found] (NodeName/AdapterName, ...) ...`
+
+**Error Message:**
+```text
+[FAIL] ManagementCompute Intent uses multiple driver versions: [Adapter Not Found] (AZLOC-NODE1/ethernet), [Driver Date 2024-04-16 Version 24.4.26429.0 NDIS 6.89] (AZLOC-NODE1/ethernet 2, pester-host2/ethernet, pester-host2/ethernet 2).
+```
+
+**Root Cause:** The specified network adapter does not exist on the system.
+
+#### Remediation Steps
+
+1) Check that the adapter exists
+
+  ```powershell
+  Get-NetAdapter -Name "AdapterName"
+  ```
+
+If the adapter is not found, ensure it has the correct name and is physically installed on the system.

--- a/TSG/EnvironmentValidator/Networking/Troubleshoot-Network-Test-NetworkAdapter-DriverConsistency.md
+++ b/TSG/EnvironmentValidator/Networking/Troubleshoot-Network-Test-NetworkAdapter-DriverConsistency.md
@@ -73,7 +73,7 @@ Review the Environment Validator output JSON. Check the `AdditionalData.Detail` 
 #### Remediation Steps
 
 1) Check with your hardware vendor to obtain the appropriate drivers for the Network Adapters.
-2) Update the drivers on each Network Adapter in the Network Intent to ensure they all use the same version across all nodes in the cluster. Note that the adapter's in each Network Intent must use the same driver across all nodes.
+2) Update the drivers on each Network Adapter in the Network Intent to ensure they all use the same version across all nodes in the cluster. Note that the adapters in each Network Intent must use the same driver across all nodes.
 
 ### Failure: `[FAIL] IntentName uses multiple driver versions: [Adapter Not Found] (NodeName/AdapterName, ...) ...`
 

--- a/TSG/EnvironmentValidator/Networking/Troubleshoot-Network-Test-NetworkAdapter-InboxDriver.md
+++ b/TSG/EnvironmentValidator/Networking/Troubleshoot-Network-Test-NetworkAdapter-InboxDriver.md
@@ -1,4 +1,4 @@
-# AzStackHci_Network_Test_StorageAzureLocal_Network_Test_NetworkAdapter_InboxDriverConnections_NoValidationMethod
+# AzureLocal_Network_Test_NetworkAdapter_InboxDriver
 <table border="1" cellpadding="6" cellspacing="0" style="border-collapse:collapse; margin-bottom:1em;">
   <tr>
     <th style="text-align:left; width: 180px;">Name</th>
@@ -91,4 +91,4 @@ AZLOC-NODE1 (1/2 adapters passed):  ethernet [Microsoft], ethernet 2 [Mellanox T
 
 #### Remediation Steps
 
-1) Check with your hardware vendor to obtain the appropriate drivers for the Network Adapter. Download and install the drivers on the host. Note that the adapter's in each Network Intent must use the same driver across all nodes.
+1) Check with your hardware vendor to obtain the appropriate drivers for the Network Adapter. Download and install the drivers on the host. Note that the adapters in each Network Intent must use the same driver across all nodes.

--- a/TSG/EnvironmentValidator/Networking/Troubleshoot-Network-Test-NetworkAdapter-InboxDriver.md
+++ b/TSG/EnvironmentValidator/Networking/Troubleshoot-Network-Test-NetworkAdapter-InboxDriver.md
@@ -1,0 +1,94 @@
+# AzStackHci_Network_Test_StorageAzureLocal_Network_Test_NetworkAdapter_InboxDriverConnections_NoValidationMethod
+<table border="1" cellpadding="6" cellspacing="0" style="border-collapse:collapse; margin-bottom:1em;">
+  <tr>
+    <th style="text-align:left; width: 180px;">Name</th>
+    <td><strong>AzureLocal_Network_Test_NetworkAdapter_InboxDriver</strong></td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 180px;">Severity</th>
+    <td><strong>Critical</strong>: This validator will block operations until remediated.</td>
+  </tr>
+  <tr>
+    <th style="text-align:left;">Applicable Scenarios</th>
+    <td><strong>Deployment</strong></td>
+  </tr>
+</table>
+
+## Overview
+
+This validation check fails when a network adapter that is a part of a Network Intent uses an inbox driver. Inbox drivers are not supported by Azure Local.
+
+An inbox driver will have the DriverProvider "Microsoft" or "Windows".
+
+## Requirements
+
+Adapters that are part of a Network Intent must meet the following requirements:
+1. Must exist on the system
+2. Must NOT use an inbox driver (DriverProvider "Microsoft" or "Windows")
+
+See [Azure Local - Host Network Requirements](https://docs.azure.cn/en-us/azure-local/concepts/host-network-requirements#driver-requirements) for more details.
+
+## Troubleshooting Steps
+
+### Review Environment Validator Output
+
+Review the Environment Validator output JSON. Check the `AdditionalData.Detail` field for summary of which Host's Network Adapters are not configured properly. You can identify the host by the `TargetResourceID` field, the format is `NodeName, NetworkAdapters`.
+
+```json
+{
+    "Name":  "AzureLocal_Network_Test_NetworkAdapter_InboxDriver",
+    "DisplayName":  "Validate that the Network Adapters are not using inbox drivers",
+    "Tags":  {},
+    "Title":  "Validate that the Network Adapters are not using inbox drivers",
+    "Status":  1,
+    "Severity":  2,
+    "Description":  "The Network Adapters used by a Network Intent must not use inbox drivers, unless it is a virtual deployment. Inbox drivers will have the DriverProvider equal to Microsoft or Windows. Work with your hardware vendor to obtain the appropriate drivers.",
+    "Remediation":  "https://aka.ms/azurelocal/envvalidator/InboxDrivers",
+    "TargetResourceID":  "AZLOC-NODE1, Network Adapters",
+    "TargetResourceName":  "AZLOC-NODE1, Network Adapters",
+    "TargetResourceType":  "NetworkAdapter",
+    "Timestamp":  "\/Date(1758300600191)\/",
+    "AdditionalData":  {
+                            "Detail":  "AZLOC-NODE1 (1/2 adapters passed):  ethernet [Microsoft], ethernet 2 [Mellanox Technologies Ltd.]. No adapters should use inbox (Microsoft or Windows) drivers.",
+                            "Status":  "FAILURE",
+                            "TimeStamp":  "09/19/2025 16:50:00",
+                            "Resource":  "NetworkAdapter",
+                            "Source":  "AZLOC-NODE1, Network Adapters"
+                        },
+    "HealthCheckSource":  "Manual\\Standard\\Medium\\Network\\c826ddf1"
+}
+```
+
+---
+
+### Failure: `adapter [Not Found]`
+
+**Error Message:**
+```text
+AZLOC-NODE1 (1/2 adapters passed): example-adapter [Not Found], ethernet 2 [Mellanox Technologies Ltd.]. No adapters should use inbox (Microsoft or Windows) drivers.
+```
+
+**Root Cause:** The specified network adapter does not exist on the system.
+
+#### Remediation Steps
+
+1) Check that the adapter exists
+
+  ```powershell
+  Get-NetAdapter -Name "example-adapter"
+  ```
+
+If the adapter is not found, ensure it has the correct name and is physically installed on the system.
+
+### Failure: `adapter [Microsoft]`
+
+#### Example
+```text
+AZLOC-NODE1 (1/2 adapters passed):  ethernet [Microsoft], ethernet 2 [Mellanox Technologies Ltd.]. No adapters should use inbox (Microsoft or Windows) drivers.
+```
+
+**Root Cause:** The Network Adapter is using an inbox driver, which is not supported by Azure Local.
+
+#### Remediation Steps
+
+1) Check with your hardware vendor to obtain the appropriate drivers for the Network Adapter. Download and install the drivers on the host. Note that the adapter's in each Network Intent must use the same driver across all nodes.


### PR DESCRIPTION
This change adds TSGs for the following validators:

- AzureLocal_Network_Test_ManagementAdapterReadines
- AzureLocal_Network_Test_NetworkAdapter_DriverConsistency
- AzureLocal_Network_Test_NetworkAdapter_InboxDriver

It also slightly tunes CoPilot to:
- Be less focused on perfect grammar
- Be less focused on PS implementations (more concise implementation)