### PR TITLE
Add TSG for re-creating server resource within Network Controller

### DIFF
--- a/TSG/Networking/SDN-Express/HowTo-Recreate-Server-Resource.md
+++ b/TSG/Networking/SDN-Express/HowTo-Recreate-Server-Resource.md
@@ -181,7 +181,7 @@ As part of the post validation steps, you will want to migrate a VM back onto th
 1. Ensure that resource configurationState is success.
    ```powershell
    $updatedServer = Get-SdnServer -NcUri $Global:SdnDiagnostics.EnvironmentInfo.NcUrl -ResourceRef $nodeToRepair.ResourceRef;
-   $updateServer.properties.configurationState | ConvertTo-Json -Depth 10
+   $updatedServer.properties.configurationState | ConvertTo-Json -Depth 10
    ```
    - If showing any warnings, then:
      - Move the vSwitch primary replica to clear any stale configurations and wait a few minutes. Re-run the command to check health state.


### PR DESCRIPTION
This pull request adds a comprehensive troubleshooting and recovery guide for SDN Server resources in the context of SDN Express networking. The new documentation provides step-by-step instructions for identifying, deleting, and recreating server resources when the VMSwitch has been recreated with a new Switch ID, including validation and configuration steps to ensure proper recovery.

**New Troubleshooting Guide for SDN Server Resource Recovery:**

* Added `TSG/Networking/SDN-Express/Recreate-Server-Resource.md` with detailed instructions for redeploying an SDN Server Resource after VMSwitch ID changes, including prerequisites, backup, deletion, and recreation steps.

**Configuration and Validation Steps:**

* Included PowerShell commands to verify and enable required features such as `NetworkVirtualization` and `Azure VFP Extension` on the Hyper-V host.
* Provided guidance for recreating the VMSwitch and updating related resource and registry values to reflect the new configuration.
* Outlined post-recovery validation steps to confirm connectivity and health of the SDN Server Resource, including troubleshooting tips for common issues.