### PR TITLE
Add release notes for CSSTools 1.2512.1.2240

### DIFF
--- a/TSG/CSSTools/ReleaseNotes/1.2512.1.1648.md
+++ b/TSG/CSSTools/ReleaseNotes/1.2512.1.1648.md
@@ -1,7 +1,12 @@
 This article describes the contents of the Microsoft.AzLocal.CSSTools module changes. This update includes improvements and fixes for the latest release of Microsoft.AzLocal.CSSTools that is supported to run on Azure Local deployments.
 
 # Download the update
-You can download the latest version of Microsoft.AzLocal.CSStools by running `Update-Module -Name Microsoft.AzLocal.CSSTools` on each of the Azure Local cluster nodes.
+You can download the latest version of Microsoft.AzLocal.CSStools by running `Update-Module -Name Microsoft.AzLocal.CSSTools` on each of the Azure Local cluster nodes. After you have downloaded the module, ensure you remove the current version from runspace if already loaded and import the latest version.
+
+```powershell
+Remove-Module -Name Microsoft.AzLocal.CSSTools
+Import-Module -Name Microsoft.AzLocal.CSSTools
+```
 
 # What's new
 - Added new insight as part of `HostNetwork` that checks for duplicated GUIDs for vSwitches.

--- a/TSG/CSSTools/ReleaseNotes/1.2512.1.1648.md
+++ b/TSG/CSSTools/ReleaseNotes/1.2512.1.1648.md
@@ -1,10 +1,16 @@
 This article describes the contents of the Microsoft.AzLocal.CSSTools module changes. This update includes improvements and fixes for the latest release of Microsoft.AzLocal.CSSTools that is supported to run on Azure Local deployments.
 
 # Download the update
-You can download the latest version of Microsoft.AzLocal.CSStools by running `Update-Module -Name Microsoft.AzLocal.CSSTools` on each of the Azure Local cluster nodes. After you have downloaded the module, ensure you remove the current version from runspace if already loaded and import the latest version.
+You can download the latest version of Microsoft.AzLocal.CSStools by running `Update-Module -Name Microsoft.AzLocal.CSSTools` on each of the Azure Local cluster nodes. After you have downloaded the module, ensure you remove the current version from runspace by using `Remove-Module`  import the latest version using `Import-Module`.
 
 ```powershell
+# update the current module directly from PowerShell Gallery
+Update-Module -Name Microsoft.AzLocal.CSSTools
+
+# remove the current version from the runspace in case it was already imported prior to update
 Remove-Module -Name Microsoft.AzLocal.CSSTools
+
+# load the latest version into the runspace
 Import-Module -Name Microsoft.AzLocal.CSSTools
 ```
 

--- a/TSG/CSSTools/ReleaseNotes/1.2512.1.1648.md
+++ b/TSG/CSSTools/ReleaseNotes/1.2512.1.1648.md
@@ -1,0 +1,11 @@
+This article describes the contents of the Microsoft.AzLocal.CSSTools module changes. This update includes improvements and fixes for the latest release of Microsoft.AzLocal.CSSTools that is supported to run on Azure Local deployments.
+
+# Download the update
+You can download the latest version of Microsoft.AzLocal.CSStools by running `Update-Module -Name Microsoft.AzLocal.CSSTools` on each of the Azure Local cluster nodes.
+
+# What's new
+- Added new insight as part of `HostNetwork` that checks for duplicated GUIDs for vSwitches.
+- Added a new function called `Get-AzsSupportStorageHealthActionDetail` that gets the storage health actions with enhanced object information and filtering options.
+- Added component validation for `Invoke-AzsSupportInsight`.
+- Updated remediation details for storage related health insights.
+- Numerous other stability and fault tolerance fixes into insights framework.

--- a/TSG/CSSTools/ReleaseNotes/1.2512.1.1648.md
+++ b/TSG/CSSTools/ReleaseNotes/1.2512.1.1648.md
@@ -9,3 +9,6 @@ You can download the latest version of Microsoft.AzLocal.CSStools by running `Up
 - Added component validation for `Invoke-AzsSupportInsight`.
 - Updated remediation details for storage related health insights.
 - Numerous other stability and fault tolerance fixes into insights framework.
+
+# Contact Us
+If you are encountering an issue, or need assistance, refer to [questions-or-feedback](https://learn.microsoft.com/en-us/azure/azure-local/manage/support-tools#questions-or-feedback).

--- a/TSG/CSSTools/ReleaseNotes/1.2512.1.2240.md
+++ b/TSG/CSSTools/ReleaseNotes/1.2512.1.2240.md
@@ -1,7 +1,7 @@
 This article describes the contents of the Microsoft.AzLocal.CSSTools 1.2512.1.2240 module changes. This update includes improvements and fixes for the latest release of Microsoft.AzLocal.CSSTools that is supported to run on Azure Local deployments.
 
 # Download the update
-You can download the latest version of Microsoft.AzLocal.CSStools by running `Update-Module -Name Microsoft.AzLocal.CSSTools` on each of the Azure Local cluster nodes. After you have downloaded the module, ensure you remove the current version from runspace by using `Remove-Module`  import the latest version using `Import-Module`.
+You can download the latest version of Microsoft.AzLocal.CSSTools by running `Update-Module -Name Microsoft.AzLocal.CSSTools` on each of the Azure Local cluster nodes. After you have downloaded the module, ensure you remove the current version from runspace by using `Remove-Module` and import the latest version using `Import-Module`.
 
 ```powershell
 # update the current module directly from PowerShell Gallery

--- a/TSG/CSSTools/ReleaseNotes/1.2512.1.2240.md
+++ b/TSG/CSSTools/ReleaseNotes/1.2512.1.2240.md
@@ -18,7 +18,7 @@ Import-Module -Name Microsoft.AzLocal.CSSTools
 - Added new insight as part of `HostNetwork` that checks for duplicated GUIDs for vSwitches.
 - Added a new function called `Get-AzsSupportStorageHealthActionDetail` that gets the storage health actions with enhanced object information and filtering options.
 - Added component validation for `Invoke-AzsSupportInsight`.
-- Updated remediation details for storage related health insights.
+- Updated remediation details for storage-related health insights.
 - Numerous other stability and fault tolerance fixes into insights framework.
 
 # Known Issues

--- a/TSG/CSSTools/ReleaseNotes/1.2512.1.2240.md
+++ b/TSG/CSSTools/ReleaseNotes/1.2512.1.2240.md
@@ -21,5 +21,8 @@ Import-Module -Name Microsoft.AzLocal.CSSTools
 - Updated remediation details for storage related health insights.
 - Numerous other stability and fault tolerance fixes into insights framework.
 
+# Known Issues
+- `Windows.System.Process.State` reports as `Unknown`. This should be reported as `Failure` as the process is not present. If you see this reported, treat it as a failure and troubleshoot why the process is not present on the system. 
+
 # Contact Us
 If you are encountering an issue, or need assistance, refer to [questions-or-feedback](https://learn.microsoft.com/en-us/azure/azure-local/manage/support-tools#questions-or-feedback).

--- a/TSG/CSSTools/ReleaseNotes/1.2512.1.2240.md
+++ b/TSG/CSSTools/ReleaseNotes/1.2512.1.2240.md
@@ -1,4 +1,4 @@
-This article describes the contents of the Microsoft.AzLocal.CSSTools module changes. This update includes improvements and fixes for the latest release of Microsoft.AzLocal.CSSTools that is supported to run on Azure Local deployments.
+This article describes the contents of the Microsoft.AzLocal.CSSTools 1.2512.1.2240 module changes. This update includes improvements and fixes for the latest release of Microsoft.AzLocal.CSSTools that is supported to run on Azure Local deployments.
 
 # Download the update
 You can download the latest version of Microsoft.AzLocal.CSStools by running `Update-Module -Name Microsoft.AzLocal.CSSTools` on each of the Azure Local cluster nodes. After you have downloaded the module, ensure you remove the current version from runspace by using `Remove-Module`  import the latest version using `Import-Module`.


### PR DESCRIPTION
This pull request adds a release notes document for the `Microsoft.AzLocal.CSSTools` module version 1.2512.1.2240. The document provides a summary of new features, improvements, and known issues for this release.

New features and improvements:

* Added a new insight to `HostNetwork` that checks for duplicated GUIDs for vSwitches.
* Introduced the `Get-AzsSupportStorageHealthActionDetail` function for enhanced storage health actions with improved object info and filtering.
* Implemented component validation for `Invoke-AzsSupportInsight`.
* Updated remediation details for storage-related health insights.
* Included various stability and fault tolerance fixes in the insights framework.

Known issues:

* The `Windows.System.Process.State` may report as `Unknown` instead of `Failure` when a process is missing; users should treat this as a failure and investigate accordingly.