### PR TITLE
Revise SCVMM certificate commands in troubleshooting guide

### DIFF
--- a/TSG/Networking/Arc-Enabled-SDN/NCHostAgent-unable-to-connect-to-ApiService-due-to-SCVMM-certificate.md
+++ b/TSG/Networking/Arc-Enabled-SDN/NCHostAgent-unable-to-connect-to-ApiService-due-to-SCVMM-certificate.md
@@ -47,7 +47,8 @@ Test-SdnCertificateMultiple : FAILED
 
 - One or more hosts unable to program SDN policies
 - Live migration to/from affected hosts results in VM network loss
-- `Debug-SdnFabricInfrastructure` reports certificate and connectivity failures
+- `Debug-SdnFabricInfrastructure -NcRestCertificate (Get-SdnServerCertificate)` reports certificate and connectivity failures
+- `Get-SdnServerCertificate` returns multiple certificates
 - Network Controller API calls fail intermittently or consistently from affected hosts
 
 ## Root Cause
@@ -93,7 +94,8 @@ flowchart TD
    On each affected host, open the local machine certificate store and look for the SCVMM self-signed certificate. It will have a subject or friendly name containing `SCVMM_CERTIFICATE_KEY_CONTAINER`.
 
    ```powershell
-   Get-SdnServerCertificate -NetworkControllerOid | Format-List Thumbprint, Subject, NotBefore, NotAfter, Issuer, FriendlyName
+   # SdnDiagnostics 4.2601.27.234 and later builds introduce a -NetworkControllerOid parameter for Get-SdnServerCertificate that should be used
+   Get-SdnServerCertificate | Format-List Thumbprint, Subject, NotBefore, NotAfter, Issuer, FriendlyName
    ```
 
 1. **Remove the conflicting SCVMM certificate**
@@ -122,7 +124,8 @@ flowchart TD
 
    ```powershell
    # Re-run SDN fabric diagnostics to confirm certificate issues are resolved
-   Debug-SdnFabricInfrastructure
+   # SdnDiagnostics 4.2601.27.234 and later builds introduce a -NetworkControllerOid parameter for Get-SdnServerCertificate that should be used
+   Debug-SdnFabricInfrastructure -NcRestCertificate (Get-SdnServerCertificate)
 
    # Verify NCHostAgent connectivity and certificate health pass
    # Expected: Test-SdnHostAgentConnectionStateToApiService and Test-SdnCertificateMultiple should now pass


### PR DESCRIPTION
This pull request updates the troubleshooting guide for Arc-Enabled SDN regarding certificate issues with the NCHostAgent and SCVMM. The changes clarify command usage and provide more accurate guidance for diagnosing and resolving certificate conflicts, especially for newer versions of SdnDiagnostics.

**Improvements to troubleshooting steps and command usage:**

* Updated references to `Debug-SdnFabricInfrastructure` to specify use of the `-NcRestCertificate` parameter and to pipe in results from `Get-SdnServerCertificate`, clarifying the diagnostic process. [[1]](diffhunk://#diff-bf16ed2ace4a32ecb4b589b3ea6b177b354bff46aa6366829c600db17985963fL50-R51) [[2]](diffhunk://#diff-bf16ed2ace4a32ecb4b589b3ea6b177b354bff46aa6366829c600db17985963fL125-R128)
* Clarified that `Get-SdnServerCertificate` may return multiple certificates and highlighted the importance of checking for this scenario.
* Added notes about the introduction of the `-NetworkControllerOid` parameter for `Get-SdnServerCertificate` in SdnDiagnostics 4.2601.27.234 and later, and updated example PowerShell commands accordingly. [[1]](diffhunk://#diff-bf16ed2ace4a32ecb4b589b3ea6b177b354bff46aa6366829c600db17985963fL96-R98) [[2]](diffhunk://#diff-bf16ed2ace4a32ecb4b589b3ea6b177b354bff46aa6366829c600db17985963fL125-R128)