### PR TITLE
Add TSG to fix x509 authentication between NC and Hosts after Solution Update

### DIFF
--- a/TSG/Networking/README.md
+++ b/TSG/Networking/README.md
@@ -22,6 +22,7 @@ For Network Environment Validator Resources, see [TSG/EnvironmentValidator/Netwo
 - [How To: SDN Layer 3 Gateway Configuration](SDN-Express/HowTo-SDNExpress-SDN-Layer3-Gateway-Configuration.md)
 - [Troubleshoot: Host Unreachable](SDN-Express/Troubleshoot-SDNExpress-HealthAlert-HostUnreachable.md)
 - [Troubleshoot: Outbound Connectivity Issues with NAT](SDN-Express/Troubleshoot-SDNExpress-Outbound-Connectivity-Issues-When-Using-Outbound-NAT.md)
+- [Troubleshoot: NcHostAgent Unable to Connect to ApiService After Solution Update](SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md)
 - [Troubleshoot: Recreate Intent Without SR-IOV](SDN-Express/Troubleshoot-SDNExpress-Recreate-Intent-No-SRIOV.md)
 
 ### Diagnostics

--- a/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
+++ b/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
@@ -130,7 +130,7 @@ Invoke-Command -ComputerName <NC-VM> -ScriptBlock {
 
 > **Important:** Repeat this for each Hyper-V host against every NC VM.
 
-### Install AzureStackCertificationAuthortity certificate to NC manually
+### Install AzureStackCertificationAuthority certificate to NC manually
 This is a short term mitigation that you should perform as part of your post solution update steps until a code fix is released. This only needs to be executed from one of the Hyper-V hosts. This requires [SdnDiagnostics](https://learn.microsoft.com/en-us/azure/azure-local/manage/sdn-log-collection?view=azloc-2603#install-the-sdn-diagnostics-powershell-module-on-the-client-computer) to be installed on the Network Controller VMs as well as the Hyper-V hosts. By default for Azure Local, SdnDiagnostics is included for the Hyper-V hosts.
 
 Connect to a Hyper-V host and copy the .cer file to each NC node.

--- a/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
+++ b/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
@@ -127,7 +127,7 @@ Invoke-Command -ComputerName 'NC1','NC2','NC3' -ScriptBlock {
 ```
 
 ### Install AzureStackCertificationAuthority certificate to NC manually
-This is a short term mitigation that you should perform as part of your post solution update steps until a code fix is released. This only needs to be executed from one of the Hyper-V hosts.This requires [SdnDiagnostics](https://learn.microsoft.com/en-us/azure/azure-local/manage/sdn-log-collection?view=azloc-2603#install-the-sdn-diagnostics-powershell-module-on-the-client-computer) to be installed on the Network Controller VMs as well as the Hyper-V hosts. By default for Azure Local, SdnDiagnostics is included for the Hyper-V hosts.
+This is a short term mitigation that you should perform as part of your post solution update steps until a code fix is released. This only needs to be executed from one of the Hyper-V hosts.This requires [SdnDiagnostics](https://learn.microsoft.com/en-us/azure/azure-local/manage/sdn-log-collection#install-the-sdn-diagnostics-powershell-module-on-the-client-computer) to be installed on the Network Controller VMs as well as the Hyper-V hosts. By default for Azure Local, SdnDiagnostics is included for the Hyper-V hosts.
 
 Connect to a Hyper-V host and copy the .cer file to each NC node.
   ```powershell

--- a/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
+++ b/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
@@ -45,8 +45,9 @@ Impact = "Policy configuration may not be pushed to the Hyper-V host(s) if no so
 
 **Observable behaviors:**
 
-- Network Controller is unable to program VFP policies to VMs, resulting.
-- VM traffic for VMs, especially after live-migration may break.
+- Network Controller is unable to program VFP policies to VMs.
+- Network connecitvity issues for workloads.
+- Network connectivity issues, after performing live-migration.
 
 ## Root Cause
 

--- a/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
+++ b/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
@@ -46,8 +46,8 @@ Impact = "Policy configuration may not be pushed to the Hyper-V host(s) if no so
 **Observable behaviors:**
 
 - Network Controller is unable to program VFP policies to VMs.
-- Network connecitvity issues for workloads.
-- Network connectivity issues, after performing live-migration.
+- Network connectivity issues for workloads.
+- Network connectivity issues after performing live migration.
 
 ## Root Cause
 

--- a/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
+++ b/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
@@ -1,0 +1,170 @@
+# NcHostAgent Unable to Connect to ApiService After Solution Update
+
+<table border="1" cellpadding="6" cellspacing="0" style="border-collapse:collapse; margin-bottom:1em;">
+  <tr>
+    <th style="text-align:left; width: 180px;">Component</th>
+    <td><strong>SDN Express / Network Controller</strong></td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 180px;">Severity</th>
+    <td><strong>Critical</strong></td>
+  </tr>
+  <tr>
+    <th style="text-align:left;">Applicable Scenarios</th>
+    <td><strong>Solution Update</strong></td>
+  </tr>
+  <tr>
+    <th style="text-align:left;">Affected Versions</th>
+    <td><strong>All versions</strong></td>
+  </tr>
+</table>
+
+## Overview
+
+After completing an Azure Local solution update, Network Controller (NC) loses the ability to manage Hyper-V hosts due to a certificate rotation failure. The solution update rotates host certificates, but the corresponding AzureStackCertificationAuthority certificate is not properly propagated to the Network Controller VMs. This causes the NcHostAgent on each host to fail authentication when connecting to the NC ApiService, effectively breaking SDN management across the cluster.
+
+This issue recurs after every subsequent solution update until the underlying root cause is addressed.
+
+## Symptoms
+
+**Common error messages:**
+
+The NcHostAgent service on the Hyper-V hosts reports connectivity failures to the Network Controller ApiService.
+
+```
+NcHostAgent unable to connect to ApiService
+```
+
+**Observable behaviors:**
+
+- Network Controller cannot manage Hyper-V hosts after a solution update
+- SDN policies are no longer applied to tenant VMs
+- Virtual network connectivity may be disrupted
+- NcHostAgent service on the hosts fails to authenticate with Network Controller
+- The issue reoccurs after each subsequent solution update
+
+## Root Cause
+
+During a solution update, the host certificates are rotated by ECE (Environment Configuration Engine). For the certificate rotation to also propagate the AzureStackCertificationAuthority certificate to the Network Controller VMs, the following registry key must exist and be populated on each Hyper-V host:
+
+```
+HKLM:\SYSTEM\CurrentControlSet\Services\NcHostAgent\Parameters\NetworkControllerNodeNames
+```
+
+This registry key is created by Windows Admin Center (WAC) during SDN deployment. In environments where WAC was not used (e.g., SdnExpress-based deployments or brownfield configurations), this registry key does not exist. When the key is missing, the secret rotation process silently skips the NC and SLB certificate injection and incorrectly reports success.
+
+As a result, after the update the hosts present new certificates that the Network Controller does not trust, breaking the NcHostAgent-to-ApiService connection.
+
+## Resolution
+
+### Prerequisites
+
+- Administrative access to the Hyper-V host nodes
+- Administrative access to the Network Controller VMs
+- [SdnDiagnostics](https://github.com/microsoft/SdnDiagnostics/wiki) PowerShell module installed
+
+### Steps
+
+1. **Validate the registry key exists and is populated**
+
+   On each Hyper-V host, verify that the `NetworkControllerNodeNames` registry key exists and contains the Network Controller VM names.
+
+   ```powershell
+   # Check if the registry key exists and has a value
+   $regPath = "HKLM:\SYSTEM\CurrentControlSet\Services\NcHostAgent\Parameters"
+   $regValue = Get-ItemProperty -Path $regPath -Name "NetworkControllerNodeNames" -ErrorAction SilentlyContinue
+
+   if ($null -eq $regValue) {
+       Write-Host "NetworkControllerNodeNames registry key is MISSING." -ForegroundColor Red
+   }
+   elseif ([string]::IsNullOrWhiteSpace($regValue.NetworkControllerNodeNames)) {
+       Write-Host "NetworkControllerNodeNames registry key EXISTS but is EMPTY." -ForegroundColor Yellow
+   }
+   else {
+       Write-Host "NetworkControllerNodeNames: $($regValue.NetworkControllerNodeNames)" -ForegroundColor Green
+   }
+   ```
+
+   If the key is missing or empty, populate it with the Network Controller VM names (comma-separated):
+
+   ```powershell
+   # Replace <NC-VM1>,<NC-VM2>,<NC-VM3> with your actual NC VM names
+   $ncNodeNames = "<NC-VM1>,<NC-VM2>,<NC-VM3>"
+   Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\NcHostAgent\Parameters" -Name "NetworkControllerNodeNames" -Value $ncNodeNames
+   ```
+
+   > **Important:** Repeat this step on every Hyper-V host in the cluster.
+
+2. **Validate local administrator permissions on Network Controller VMs**
+
+   The certificate rotation process requires that the Hyper-V hosts can remotely manage the Network Controller VMs. Verify that the cluster nodes have local administrator permissions on each NC VM.
+
+   ```powershell
+   # Run from a Hyper-V host against each NC VM
+   # Replace <NC-VM> with your NC VM name
+   Invoke-Command -ComputerName <NC-VM> -ScriptBlock {
+       $adminGroup = Get-LocalGroupMember -Group "Administrators" -ErrorAction SilentlyContinue
+       $adminGroup | Format-Table Name, ObjectClass, PrincipalSource
+   }
+   ```
+
+   If the cluster nodes are not listed as local administrators, add them:
+
+   ```powershell
+   # Run on each NC VM
+   # Replace <DOMAIN\ClusterNode$> with your cluster node machine account
+   Invoke-Command -ComputerName <NC-VM> -ScriptBlock {
+       Add-LocalGroupMember -Group "Administrators" -Member "<DOMAIN\ClusterNode$>"
+   }
+   ```
+
+   > **Important:** Repeat this for each Hyper-V host against every NC VM.
+
+3. **Run certificate rotation to restore connectivity (short-term mitigation)**
+
+   Use `Start-SdnServerCertificateRotation` from the SdnDiagnostics module to manually trigger certificate rotation and restore the NcHostAgent-to-ApiService connection.
+
+   ```powershell
+   # Import the SdnDiagnostics module if not already loaded
+   Import-Module SdnDiagnostics
+
+   # Generate the SdnDiagnostics credential (NC admin credentials)
+   $credential = Get-Credential
+
+   # Start the certificate rotation
+   Start-SdnServerCertificateRotation -Credential $credential
+   ```
+
+   > **Note:** This is a short-term mitigation. The issue will recur on the next solution update unless the registry key (Step 1) is properly configured on all hosts before the update.
+
+4. **Verify resolution**
+
+   Confirm that the NcHostAgent service on each host can now communicate with the Network Controller.
+
+   ```powershell
+   # Check NcHostAgent service status on each host
+   Get-Service -Name NcHostAgent | Select-Object Name, Status
+
+   # Verify Network Controller connectivity by querying server resources
+   $nchaParams = Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\NcHostAgent\Parameters"
+   $ncUri = "https://$($nchaParams.PeerCertificateCName)"
+   Get-NetworkControllerServer -ConnectionUri $ncUri
+   ```
+
+   A successful response listing server resources confirms that connectivity has been restored.
+
+## Prevention
+
+To prevent this issue from recurring on future solution updates:
+
+- Ensure the `NetworkControllerNodeNames` registry key is populated on **all** Hyper-V hosts before performing a solution update
+- Verify local administrator permissions on NC VMs are correctly configured before updates
+- After any solution update, validate NcHostAgent connectivity to the Network Controller as part of post-update verification
+
+## Related Issues
+
+- [Troubleshoot: Host Not Connected to Controller](Troubleshoot-SDNExpress-HealthAlert-HostNotConnectedToController.md)
+- [Troubleshoot: Host Unreachable](Troubleshoot-SDNExpress-HealthAlert-HostUnreachable.md)
+- [SdnDiagnostics Wiki](https://github.com/microsoft/SdnDiagnostics/wiki)
+
+---

--- a/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
+++ b/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
@@ -29,23 +29,32 @@ This issue recurs after every subsequent solution update until the underlying ro
 
 **Common error messages:**
 
-The NcHostAgent service on the Hyper-V hosts reports connectivity failures to the Network Controller ApiService.
+ConfigurationState reported for /servers/{resourceId} may show failure indicating:
 
 ```
-NcHostAgent unable to connect to ApiService
+PolicyConfigurationFailure
+```
+
+If you run `Debug-SdnFabricInfrastructure`, you may see the following test reporting failure:
+
+```
+Test-SdnHostAgentConnectionStateToApiService
+Description = "Network Controller Host Agent is not connected to the Network Controller API Service."
+Impact = "Policy configuration may not be pushed to the Hyper-V host(s) if no southbound connectivity is available."
 ```
 
 **Observable behaviors:**
 
-- Network Controller cannot manage Hyper-V hosts after a solution update
-- SDN policies are no longer applied to tenant VMs
-- Virtual network connectivity may be disrupted
-- NcHostAgent service on the hosts fails to authenticate with Network Controller
-- The issue reoccurs after each subsequent solution update
+- Network Controller is unable to program VFP policies to VMs, resulting.
+- VM traffic for VMs, especially after live-migration may break.
 
 ## Root Cause
 
-During a solution update, the host certificates are rotated by ECE (Environment Configuration Engine). For the certificate rotation to also propagate the AzureStackCertificationAuthority certificate to the Network Controller VMs, the following registry key must exist and be populated on each Hyper-V host:
+During a solution update, the host certificates are rotated by ECE (Environment Configuration Engine). For the certificate rotation to also propagate the AzureStackCertificationAuthority certificate to the Network Controller VMs, several conditions must be met. A failure in any of the following causes the NcHostAgent-to-ApiService connection to break after the update.
+
+### 1. Missing NetworkControllerNodeNames Registry Key
+
+The certificate rotation process depends on the following registry key being present and populated on each Hyper-V host:
 
 ```
 HKLM:\SYSTEM\CurrentControlSet\Services\NcHostAgent\Parameters\NetworkControllerNodeNames
@@ -53,7 +62,18 @@ HKLM:\SYSTEM\CurrentControlSet\Services\NcHostAgent\Parameters\NetworkController
 
 This registry key is created by Windows Admin Center (WAC) during SDN deployment. In environments where WAC was not used (e.g., SdnExpress-based deployments or brownfield configurations), this registry key does not exist. When the key is missing, the secret rotation process silently skips the NC and SLB certificate injection and incorrectly reports success.
 
-As a result, after the update the hosts present new certificates that the Network Controller does not trust, breaking the NcHostAgent-to-ApiService connection.
+### 2. HCI Admin User Not Added to Local Administrators on NC VMs
+
+The certificate rotation process uses PowerShell remoting (`Invoke-Command`) from the Hyper-V hosts to the Network Controller VMs to install the updated certificates. If the cluster node machine accounts or the HCI admin user are not members of the Local Administrators group on the NC VMs, the remote commands fail and certificate propagation does not complete.
+
+### 3. Code Defect in Certificate Rotation Logic
+
+There is a known defect in the certificate rotation logic where:
+
+- The `Get-VM` lookup assumes VM names match the FQDN or NetBIOS name, which is not always true
+- An `Invoke-Command` argument handling issue (extra comma) results in a null argument being passed, causing the rotation to be silently skipped
+
+> **Note:** A fix for these code defects is currently in development and will be addressed in a future update.
 
 ## Resolution
 

--- a/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
+++ b/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
@@ -51,7 +51,7 @@ Impact = "Policy configuration may not be pushed to the Hyper-V host(s) if no so
 
 ## Root Cause
 
-During a solution update, the host certificates are rotated by ECE (Environment Configuration Engine). For the certificate rotation to also propagate the AzureStackCertificationAuthority certificate to the Network Controller VMs, several conditions must be met. A failure in any of the following causes the NcHostAgent-to-ApiService connection to break after the update.
+During a solution update, the host certificates are rotated automatically. For the certificate rotation to also propagate the AzureStackCertificationAuthority certificate to the Network Controller VMs, several conditions must be met. A failure in any of the following causes the NcHostAgent-to-ApiService connection to break after the update.
 
 ### 1. Missing NetworkControllerNodeNames Registry Key
 

--- a/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
+++ b/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
@@ -62,9 +62,9 @@ HKLM:\SYSTEM\CurrentControlSet\Services\NcHostAgent\Parameters\NetworkController
 
 This registry key is created by Windows Admin Center (WAC) and is created when you use WAC to manage Network Controller. In environments where WAC is not used this registry key does not exist. If this key is not present for SdnExpress deployments, we will not rotate the AzureStackCertificationAuthority.
 
-### 2. HCI Admin User Not Added to Local Administrators on NC VMs
+### 2. HCI Deployment User Not Added to Local Administrators on NC VMs
 
-The certificate rotation process uses PowerShell remoting (`Invoke-Command`) from the Hyper-V hosts to the Network Controller VMs to install the updated certificates. If the HCI admin is not a member of the Local Administrators group on the NC VMs, the remote commands fail and certificate propagation does not complete.
+The certificate rotation process uses PowerShell remoting (`Invoke-Command`) from the Hyper-V hosts to the Network Controller VMs to install the updated certificates. If the HCI deployment user is not a member of the Local Administrators group on the NC VMs, the remote commands fail and certificate propagation does not complete.
 
 ### 3. Code Defect in Certificate Rotation Logic
 
@@ -104,9 +104,9 @@ Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\NcHostAgent\Para
 
 > **Important:** Repeat this step on every Hyper-V host in the cluster.
 
-### HCI Admin User Not Added to Local Administrators on NC VMs
+### HCI Deployment User Not Added to Local Administrators on NC VMs
 
-The certificate rotation process requires that the Hyper-V hosts can remotely manage the Network Controller VMs. Verify that the cluster nodes have local administrator permissions on each NC VM.
+The certificate rotation process requires that the Hyper-V hosts can remotely manage the Network Controller VMs. Verify that the cluster nodes have local administrator permissions on each NC VM. To determine your deployment user, leverage `Get-AzsSupportLcmDeploymentUserName` included with the [Support Diagnostics Tool](https://learn.microsoft.com/en-us/azure/azure-local/manage/support-tools).
 
 ```powershell
 # Run from a Hyper-V host against each NC VM
@@ -123,7 +123,7 @@ If the cluster nodes are not listed as local administrators, add them:
 # Run on each NC VM
 # Replace <DOMAIN\ClusterNode$> with your cluster node machine account
 Invoke-Command -ComputerName <NC-VM> -ScriptBlock {
-    Add-LocalGroupMember -Group "Administrators" -Member "<DOMAIN\ClusterNode$>"
+    Add-LocalGroupMember -Group "Administrators" -Member "<DOMAIN\HCI_DEPLOY_USER>"
 }
 ```
 

--- a/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
+++ b/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
@@ -107,31 +107,27 @@ Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\NcHostAgent\Para
 
 ### HCI Deployment User Not Added to Local Administrators on NC VMs
 
-The certificate rotation process requires that the Hyper-V hosts can remotely manage the Network Controller VMs. Verify that the cluster nodes have local administrator permissions on each NC VM. To determine your deployment user, leverage `Get-AzsSupportLcmDeploymentUserName` included with the [Support Diagnostics Tool](https://learn.microsoft.com/en-us/azure/azure-local/manage/support-tools).
+The certificate rotation process requires that the Hyper-V hosts can remotely manage the Network Controller VMs. Verify that the Azure Local Deployment User has local administrator permissions on each NC VM. To determine your deployment user, leverage `Get-AzsSupportLcmDeploymentUserName` included with the [Support Diagnostics Tool](https://learn.microsoft.com/en-us/azure/azure-local/manage/support-tools).
 
 ```powershell
-# Run from a Hyper-V host against each NC VM
-# Replace <NC-VM> with your NC VM name
-Invoke-Command -ComputerName <NC-VM> -ScriptBlock {
+# run this against all the NC VMs
+Invoke-Command -ComputerName 'NC1','NC2','NC3' -ScriptBlock {
     $adminGroup = Get-LocalGroupMember -Group "Administrators" -ErrorAction SilentlyContinue
     $adminGroup | Format-Table Name, ObjectClass, PrincipalSource
 }
 ```
 
-If the cluster nodes are not listed as local administrators, add them:
+If the deployment user is not listed as local administrators, add them:
 
 ```powershell
-# Run on each NC VM
-# Replace <DOMAIN\ClusterNode$> with your cluster node machine account
-Invoke-Command -ComputerName <NC-VM> -ScriptBlock {
-    Add-LocalGroupMember -Group "Administrators" -Member "<DOMAIN\HCI_DEPLOY_USER>"
+# Replace <DOMAIN\DEPLOY_USER> with your deployment user account identified
+Invoke-Command -ComputerName 'NC1','NC2','NC3' -ScriptBlock {
+    Add-LocalGroupMember -Group "Administrators" -Member "<DOMAIN\DEPLOY_USER>"
 }
 ```
 
-> **Important:** Repeat this for each Hyper-V host against every NC VM.
-
 ### Install AzureStackCertificationAuthortity certificate to NC manually
-This is a short term mitigation that you should perform as part of your post solution update steps until a code fix is released. This only needs to be executed from one of the Hyper-V hosts. This requires [SdnDiagnostics](https://learn.microsoft.com/en-us/azure/azure-local/manage/sdn-log-collection?view=azloc-2603#install-the-sdn-diagnostics-powershell-module-on-the-client-computer) to be installed on the Network Controller VMs as well as the Hyper-V hosts. By default for Azure Local, SdnDiagnostics is included for the Hyper-V hosts.
+This is a short term mitigation that you should perform as part of your post solution update steps until a code fix is released. This only needs to be executed from one of the Hyper-V hosts.This requires [SdnDiagnostics](https://learn.microsoft.com/en-us/azure/azure-local/manage/sdn-log-collection?view=azloc-2603#install-the-sdn-diagnostics-powershell-module-on-the-client-computer) to be installed on the Network Controller VMs as well as the Hyper-V hosts. By default for Azure Local, SdnDiagnostics is included for the Hyper-V hosts.
 
 Connect to a Hyper-V host and copy the .cer file to each NC node.
   ```powershell
@@ -142,7 +138,7 @@ Connect to a Hyper-V host and copy the .cer file to each NC node.
   else {
     $rootDir = 'C:\ClusterStorage\Infrastructure_1\Shares\SU1_Infrastructure_1\AzureStackCertificateAuthority'
   }
-  Copy-SdnFileToComputer -Path (Join-Path -Path $rootDir -ChildPath "AzureStackCertificationAuthority.cer" -Destination (Get-SdnWorkingDirectory) -ComputerName 'NC1','NC2','NC3'
+  Copy-SdnFileToComputer -Path (Join-Path -Path $rootDir -ChildPath "AzureStackCertificationAuthority.cer") -Destination (Get-SdnWorkingDirectory) -ComputerName 'NC1','NC2','NC3'
   ```
 
 Install the certificate into trusted root store.

--- a/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
+++ b/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
@@ -131,28 +131,26 @@ Invoke-Command -ComputerName <NC-VM> -ScriptBlock {
 > **Important:** Repeat this for each Hyper-V host against every NC VM.
 
 ### Install AzureStackCertificationAuthortity certificate to NC manually
-This is a short term mitigation that you should perform as part of your post solution update steps until a code fix is released. This only needs to be executed from one of the Hyper-V hosts.
+This is a short term mitigation that you should perform as part of your post solution update steps until a code fix is released. This only needs to be executed from one of the Hyper-V hosts. This requires [SdnDiagnostics](https://learn.microsoft.com/en-us/azure/azure-local/manage/sdn-log-collection?view=azloc-2603#install-the-sdn-diagnostics-powershell-module-on-the-client-computer) to be installed on the Network Controller VMs as well as the Hyper-V hosts. By default for Azure Local, SdnDiagnostics is included for the Hyper-V hosts.
 
-This requires [SdnDiagnostics](https://learn.microsoft.com/en-us/azure/azure-local/manage/sdn-log-collection?view=azloc-2603#install-the-sdn-diagnostics-powershell-module-on-the-client-computer) to be installed on the Network Controller VMs as well as the Hyper-V hosts. By default for Azure Local, SdnDiagnostics is included for the Hyper-V hosts.
+Connect to a Hyper-V host and copy the .cer file to each NC node.
+  ```powershell
+  $currentVersion = (Get-SolutionUpdateEnvironment -ErrorAction Stop).CurrentVersion
+  if ($($currentVersion.Minor) -ge 2604) {
+    $rootDir = 'C:\ProgramData\AzureEdge\CertificateStore\LocalMachine\Root'
+  }
+  else {
+    $rootDir = 'C:\ClusterStorage\Infrastructure_1\Shares\SU1_Infrastructure_1\AzureStackCertificateAuthority'
+  }
+  Copy-SdnFileToComputer -Path (Join-Path -Path $rootDir -ChildPath "AzureStackCertificationAuthority.cer" -Destination (Get-SdnWorkingDirectory) -ComputerName 'NC1','NC2','NC3'
+  ```
 
-1. Connect to a Hyper-V host and copy the .cer file to each NC node.
-    ```powershell
-    $currentVersion = (Get-SolutionUpdateEnvironment -ErrorAction Stop).CurrentVersion
-    if ($($currentVersion.Minor) -ge 2604) {
-      $rootDir = 'C:\ProgramData\AzureEdge\CertificateStore\LocalMachine\Root'
-    }
-    else {
-      $rootDir = 'C:\ClusterStorage\Infrastructure_1\Shares\SU1_Infrastructure_1\AzureStackCertificateAuthority'
-    }
-    Copy-SdnFileToComputer -Path (Join-Path -Path $rootDir -ChildPath "AzureStackCertificationAuthority.cer" -Destination (Get-SdnWorkingDirectory) -ComputerName 'NC1','NC2','NC3'
-    ```
-
-1. Install the certificate into trusted root store.
-    ```powershell
-    Invoke-SdnCommand -ComputerName 'NC1','NC2','NC3' -ScriptBlock {
-      $cert = Get-ChildItem -Path "$(Get-SdnWorkingDirectory)\AzureStackCertificationAuthority.cer"
-      Import-SdnCertificate -FilePath $cert.FullName -CertStore 'Cert:\LocalMachine\Root'
-    }
-    ```
+Install the certificate into trusted root store.
+  ```powershell
+  Invoke-SdnCommand -ComputerName 'NC1','NC2','NC3' -ScriptBlock {
+    $cert = Get-ChildItem -Path "$(Get-SdnWorkingDirectory)\AzureStackCertificationAuthority.cer"
+    Import-SdnCertificate -FilePath $cert.FullName -CertStore 'Cert:\LocalMachine\Root'
+  }
+  ```
 
 Alternatively, if you have SdnDiagnostics with version 4.2604 or later, you can leverage [Start-SdnServerCertificateRotation](https://learn.microsoft.com/en-us/azure/azure-local/manage/update-sdn-infrastructure-certificates) from the Hyper-V host which will automatically detect the AzureStackCertificationAuthority certificate and copy to Network Controller VMs.

--- a/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
+++ b/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
@@ -15,7 +15,7 @@
   </tr>
   <tr>
     <th style="text-align:left;">Affected Versions</th>
-    <td><strong>All versions</strong></td>
+    <td><strong>2506,2507,2508,2509,2510,2511,2512,2601,2602,2603,2604</strong></td>
   </tr>
 </table>
 
@@ -60,131 +60,98 @@ The certificate rotation process depends on the following registry key being pre
 HKLM:\SYSTEM\CurrentControlSet\Services\NcHostAgent\Parameters\NetworkControllerNodeNames
 ```
 
-This registry key is created by Windows Admin Center (WAC) during SDN deployment. In environments where WAC was not used (e.g., SdnExpress-based deployments or brownfield configurations), this registry key does not exist. When the key is missing, the secret rotation process silently skips the NC and SLB certificate injection and incorrectly reports success.
+This registry key is created by Windows Admin Center (WAC) and is created when you use WAC to manage Network Controller. In environments where WAC is not used this registry key does not exist. If this key is not present for SdnExpress deployments, we will not rotate the AzureStackCertificationAuthority.
 
 ### 2. HCI Admin User Not Added to Local Administrators on NC VMs
 
-The certificate rotation process uses PowerShell remoting (`Invoke-Command`) from the Hyper-V hosts to the Network Controller VMs to install the updated certificates. If the cluster node machine accounts or the HCI admin user are not members of the Local Administrators group on the NC VMs, the remote commands fail and certificate propagation does not complete.
+The certificate rotation process uses PowerShell remoting (`Invoke-Command`) from the Hyper-V hosts to the Network Controller VMs to install the updated certificates. If the HCI admin is not a member of the Local Administrators group on the NC VMs, the remote commands fail and certificate propagation does not complete.
 
 ### 3. Code Defect in Certificate Rotation Logic
 
-There is a known defect in the certificate rotation logic where:
-
-- The `Get-VM` lookup assumes VM names match the FQDN or NetBIOS name, which is not always true
-- An `Invoke-Command` argument handling issue (extra comma) results in a null argument being passed, causing the rotation to be silently skipped
+There is a known defect in the certificate rotation logic where incorrect name validation is performed, resulting in us skipping the rotate and marking the step as Success.
 
 > **Note:** A fix for these code defects is currently in development and will be addressed in a future update.
 
 ## Resolution
 
-### Prerequisites
+### Missing NetworkControllerNodeNames Registry Key
 
-- Administrative access to the Hyper-V host nodes
-- Administrative access to the Network Controller VMs
-- [SdnDiagnostics](https://github.com/microsoft/SdnDiagnostics/wiki) PowerShell module installed
+On each Hyper-V host, verify that the `NetworkControllerNodeNames` registry key exists and contains the Network Controller VM names.
 
-### Steps
+```powershell
+# Check if the registry key exists and has a value
+$regPath = "HKLM:\SYSTEM\CurrentControlSet\Services\NcHostAgent\Parameters"
+$regValue = Get-ItemProperty -Path $regPath -Name "NetworkControllerNodeNames" -ErrorAction SilentlyContinue
 
-1. **Validate the registry key exists and is populated**
+if ($null -eq $regValue) {
+    Write-Host "NetworkControllerNodeNames registry key is MISSING." -ForegroundColor Red
+}
+elseif ([string]::IsNullOrWhiteSpace($regValue.NetworkControllerNodeNames)) {
+    Write-Host "NetworkControllerNodeNames registry key EXISTS but is EMPTY." -ForegroundColor Yellow
+}
+else {
+    Write-Host "NetworkControllerNodeNames: $($regValue.NetworkControllerNodeNames)" -ForegroundColor Green
+}
+```
 
-   On each Hyper-V host, verify that the `NetworkControllerNodeNames` registry key exists and contains the Network Controller VM names.
+If the key is missing or empty, populate it with the Network Controller VM names (comma-separated):
 
-   ```powershell
-   # Check if the registry key exists and has a value
-   $regPath = "HKLM:\SYSTEM\CurrentControlSet\Services\NcHostAgent\Parameters"
-   $regValue = Get-ItemProperty -Path $regPath -Name "NetworkControllerNodeNames" -ErrorAction SilentlyContinue
+```powershell
+# Replace <NC-VM1>,<NC-VM2>,<NC-VM3> with your actual NC VM names
+$ncNodeNames = "<NC-VM1>,<NC-VM2>,<NC-VM3>"
+Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\NcHostAgent\Parameters" -Name "NetworkControllerNodeNames" -Value $ncNodeNames
+```
 
-   if ($null -eq $regValue) {
-       Write-Host "NetworkControllerNodeNames registry key is MISSING." -ForegroundColor Red
-   }
-   elseif ([string]::IsNullOrWhiteSpace($regValue.NetworkControllerNodeNames)) {
-       Write-Host "NetworkControllerNodeNames registry key EXISTS but is EMPTY." -ForegroundColor Yellow
-   }
-   else {
-       Write-Host "NetworkControllerNodeNames: $($regValue.NetworkControllerNodeNames)" -ForegroundColor Green
-   }
-   ```
+> **Important:** Repeat this step on every Hyper-V host in the cluster.
 
-   If the key is missing or empty, populate it with the Network Controller VM names (comma-separated):
+### HCI Admin User Not Added to Local Administrators on NC VMs
 
-   ```powershell
-   # Replace <NC-VM1>,<NC-VM2>,<NC-VM3> with your actual NC VM names
-   $ncNodeNames = "<NC-VM1>,<NC-VM2>,<NC-VM3>"
-   Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\NcHostAgent\Parameters" -Name "NetworkControllerNodeNames" -Value $ncNodeNames
-   ```
+The certificate rotation process requires that the Hyper-V hosts can remotely manage the Network Controller VMs. Verify that the cluster nodes have local administrator permissions on each NC VM.
 
-   > **Important:** Repeat this step on every Hyper-V host in the cluster.
+```powershell
+# Run from a Hyper-V host against each NC VM
+# Replace <NC-VM> with your NC VM name
+Invoke-Command -ComputerName <NC-VM> -ScriptBlock {
+    $adminGroup = Get-LocalGroupMember -Group "Administrators" -ErrorAction SilentlyContinue
+    $adminGroup | Format-Table Name, ObjectClass, PrincipalSource
+}
+```
 
-2. **Validate local administrator permissions on Network Controller VMs**
+If the cluster nodes are not listed as local administrators, add them:
 
-   The certificate rotation process requires that the Hyper-V hosts can remotely manage the Network Controller VMs. Verify that the cluster nodes have local administrator permissions on each NC VM.
+```powershell
+# Run on each NC VM
+# Replace <DOMAIN\ClusterNode$> with your cluster node machine account
+Invoke-Command -ComputerName <NC-VM> -ScriptBlock {
+    Add-LocalGroupMember -Group "Administrators" -Member "<DOMAIN\ClusterNode$>"
+}
+```
 
-   ```powershell
-   # Run from a Hyper-V host against each NC VM
-   # Replace <NC-VM> with your NC VM name
-   Invoke-Command -ComputerName <NC-VM> -ScriptBlock {
-       $adminGroup = Get-LocalGroupMember -Group "Administrators" -ErrorAction SilentlyContinue
-       $adminGroup | Format-Table Name, ObjectClass, PrincipalSource
-   }
-   ```
+> **Important:** Repeat this for each Hyper-V host against every NC VM.
 
-   If the cluster nodes are not listed as local administrators, add them:
+### Install AzureStackCertificationAuthortity certificate to NC manually
+This is a short term mitigation that you should perform as part of your post solution update steps until a code fix is released. This only needs to be executed from one of the Hyper-V hosts.
 
-   ```powershell
-   # Run on each NC VM
-   # Replace <DOMAIN\ClusterNode$> with your cluster node machine account
-   Invoke-Command -ComputerName <NC-VM> -ScriptBlock {
-       Add-LocalGroupMember -Group "Administrators" -Member "<DOMAIN\ClusterNode$>"
-   }
-   ```
+This requires [SdnDiagnostics](https://learn.microsoft.com/en-us/azure/azure-local/manage/sdn-log-collection?view=azloc-2603#install-the-sdn-diagnostics-powershell-module-on-the-client-computer) to be installed on the Network Controller VMs as well as the Hyper-V hosts. By default for Azure Local, SdnDiagnostics is included for the Hyper-V hosts.
 
-   > **Important:** Repeat this for each Hyper-V host against every NC VM.
+1. Connect to a Hyper-V host and copy the .cer file to each NC node.
+    ```powershell
+    $currentVersion = (Get-SolutionUpdateEnvironment -ErrorAction Stop).CurrentVersion
+    if ($($currentVersion.Minor) -ge 2604) {
+      $rootDir = 'C:\ProgramData\AzureEdge\CertificateStore\LocalMachine\Root'
+    }
+    else {
+      $rootDir = 'C:\ClusterStorage\Infrastructure_1\Shares\SU1_Infrastructure_1\AzureStackCertificateAuthority'
+    }
+    Copy-SdnFileToComputer -Path (Join-Path -Path $rootDir -ChildPath "AzureStackCertificationAuthority.cer" -Destination (Get-SdnWorkingDirectory) -ComputerName 'NC1','NC2','NC3'
+    ```
 
-3. **Run certificate rotation to restore connectivity (short-term mitigation)**
+1. Install the certificate into trusted root store.
+    ```powershell
+    Invoke-SdnCommand -ComputerName 'NC1','NC2','NC3' -ScriptBlock {
+      $cert = Get-ChildItem -Path "$(Get-SdnWorkingDirectory)\AzureStackCertificationAuthority.cer"
+      Import-SdnCertificate -FilePath $cert.FullName -CertStore 'Cert:\LocalMachine\Root'
+    }
+    ```
 
-   Use `Start-SdnServerCertificateRotation` from the SdnDiagnostics module to manually trigger certificate rotation and restore the NcHostAgent-to-ApiService connection.
-
-   ```powershell
-   # Import the SdnDiagnostics module if not already loaded
-   Import-Module SdnDiagnostics
-
-   # Generate the SdnDiagnostics credential (NC admin credentials)
-   $credential = Get-Credential
-
-   # Start the certificate rotation
-   Start-SdnServerCertificateRotation -Credential $credential
-   ```
-
-   > **Note:** This is a short-term mitigation. The issue will recur on the next solution update unless the registry key (Step 1) is properly configured on all hosts before the update.
-
-4. **Verify resolution**
-
-   Confirm that the NcHostAgent service on each host can now communicate with the Network Controller.
-
-   ```powershell
-   # Check NcHostAgent service status on each host
-   Get-Service -Name NcHostAgent | Select-Object Name, Status
-
-   # Verify Network Controller connectivity by querying server resources
-   $nchaParams = Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\NcHostAgent\Parameters"
-   $ncUri = "https://$($nchaParams.PeerCertificateCName)"
-   Get-NetworkControllerServer -ConnectionUri $ncUri
-   ```
-
-   A successful response listing server resources confirms that connectivity has been restored.
-
-## Prevention
-
-To prevent this issue from recurring on future solution updates:
-
-- Ensure the `NetworkControllerNodeNames` registry key is populated on **all** Hyper-V hosts before performing a solution update
-- Verify local administrator permissions on NC VMs are correctly configured before updates
-- After any solution update, validate NcHostAgent connectivity to the Network Controller as part of post-update verification
-
-## Related Issues
-
-- [Troubleshoot: Host Not Connected to Controller](Troubleshoot-SDNExpress-HealthAlert-HostNotConnectedToController.md)
-- [Troubleshoot: Host Unreachable](Troubleshoot-SDNExpress-HealthAlert-HostUnreachable.md)
-- [SdnDiagnostics Wiki](https://github.com/microsoft/SdnDiagnostics/wiki)
-
----
+Alternatively, if you have SdnDiagnostics with version 4.2604 or later, you can leverage [Start-SdnServerCertificateRotation](https://learn.microsoft.com/en-us/azure/azure-local/manage/update-sdn-infrastructure-certificates) from the Hyper-V host which will automatically detect the AzureStackCertificationAuthority certificate and copy to Network Controller VMs.

--- a/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
+++ b/TSG/Networking/SDN-Express/Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md
@@ -100,7 +100,12 @@ If the key is missing or empty, populate it with the Network Controller VM names
 ```powershell
 # Replace <NC-VM1>,<NC-VM2>,<NC-VM3> with your actual NC VM names
 $ncNodeNames = "<NC-VM1>,<NC-VM2>,<NC-VM3>"
+
+# update existing key if present
 Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\NcHostAgent\Parameters" -Name "NetworkControllerNodeNames" -Value $ncNodeNames
+
+# create key if missing
+New-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\NcHostAgent\Parameters' -Name 'NetworkControllerNodeNames' -Value $nodeNames -PropertyType "MultiString" -Force
 ```
 
 > **Important:** Repeat this step on every Hyper-V host in the cluster.


### PR DESCRIPTION
This pull request adds new troubleshooting documentation for a critical SDN Express issue where `NcHostAgent` is unable to connect to the `ApiService` after a solution update. The documentation outlines the problem, root causes, and provides step-by-step resolution guidance. The main changes are:

**Documentation Additions:**

* Added a new troubleshooting guide: `Troubleshoot-SDNExpress-NcHostAgent-Unable-To-Connect-ApiService-After-Solution-Update.md`, which covers symptoms, root causes, and resolutions for the `NcHostAgent` connection issue following solution updates.
* Updated `README.md` to include a link to the new troubleshooting document, making it easier to find and reference.