### PR TITLE
Tsg/update fails arc agent install

### DIFF
--- a/TSG/Update/README.md
+++ b/TSG/Update/README.md
@@ -33,3 +33,4 @@
 * [2509 | Update Service terminated repeatedly by ALM due to high memory usage](./Update-Service-terminated-repeatedly-by-ALM.md)
 * [2601 | Solution Update failed with error message "Access is denied" ] (./AZLUpdate2601.md)
 * [Test-AzStackHciARBStack: Fails on Non-Numeric Az CLI Extension Versions](./Test-AzStackHciARBStack-NonNumericAzCLIExtensionVersions.md)
+* [Update fails due to Arc Agent install failure (lockdown on azcmagent.log)](./Update-fails-due-to-Arc-Agent-install-failure.md)

--- a/TSG/Update/Update-fails-due-to-Arc-Agent-install-failure.md
+++ b/TSG/Update/Update-fails-due-to-Arc-Agent-install-failure.md
@@ -1,0 +1,81 @@
+# Update Fails Due to Arc Agent Install Failure
+
+<table border="1" cellpadding="6" cellspacing="0" style="border-collapse:collapse; margin-bottom:1em;">
+  <tr>
+    <th style="text-align:left; width: 180px;">Component</th>
+    <td><strong>Arc Agent</strong></td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 180px;">Severity</th>
+    <td><strong>High</strong></td>
+  </tr>
+  <tr>
+    <th style="text-align:left;">Applicable Scenarios</th>
+    <td><strong>Update</strong></td>
+  </tr>
+  <tr>
+    <th style="text-align:left;">Affected Versions</th>
+    <td><strong>All versions</strong></td>
+  </tr>
+</table>
+
+## Overview
+
+Azure Local update may fail during Arc agent installation due to a file lockdown issue. The `azcmagent.log` file under `C:\ProgramData\AzureConnectedMachineAgent\Log` can become locked, preventing the Arc agent installer from completing successfully.
+
+## Symptoms
+
+- Solution update fails during Arc agent installation step.
+- Arc agent install logs indicate a lockdown or file access issue.
+
+**Common error messages:**
+
+Check `C:\ImageComposition\ArcAgent\arcInstallLog.txt` on the affected node(s) for errors referencing a lockdown or inability to access the log file.
+
+**Observable behaviors:**
+
+- Update does not progress past the Arc agent installation phase.
+- The `arcInstallLog.txt` file on one or more nodes contains lockdown-related errors.
+
+## Root Cause
+
+The Arc agent log file (`C:\ProgramData\AzureConnectedMachineAgent\Log\azcmagent.log`) becomes locked, which prevents the Arc agent installer from writing to it during the update process. This causes the installation to fail and blocks the overall update.
+
+## Resolution
+
+### Prerequisites
+
+- Remote PowerShell access or local console access to the affected cluster node(s).
+
+### Steps
+
+1. **Diagnose the issue**
+   Review the Arc agent install log on each affected node to confirm the lockdown error.
+
+   ```powershell
+   Get-Content "C:\ImageComposition\ArcAgent\arcInstallLog.txt" | Select-String -Pattern "lock"
+   ```
+
+2. **Back up the locked log file**
+   Move the `azcmagent.log` file to a backup location outside of the `C:\ProgramData\AzureConnectedMachineAgent` directory. This releases the lock and allows the installer to create a fresh log file.
+
+   ```powershell
+   # Create a backup directory if it doesn't exist
+   New-Item -ItemType Directory -Path "C:\Temp\ArcAgentLogBackup" -Force
+
+   # Move the locked log file to the backup location
+   Move-Item -Path "C:\ProgramData\AzureConnectedMachineAgent\Log\azcmagent.log" -Destination "C:\Temp\ArcAgentLogBackup\azcmagent.log" -Force
+   ```
+
+   > **Note:** Repeat this step on all affected nodes in the cluster.
+
+3. **Retry the update**
+   Attempt the update again. The Arc agent installer should now be able to proceed without the lockdown issue.
+
+4. **Verify resolution**
+   ```powershell
+   # Confirm the update is progressing past the Arc agent install step
+   Get-SolutionUpdate | Format-Table -Property Title, State, Status
+   ```
+
+---

--- a/TSG/Update/Update-fails-due-to-Arc-Agent-install-failure.md
+++ b/TSG/Update/Update-fails-due-to-Arc-Agent-install-failure.md
@@ -47,7 +47,7 @@ Check `C:\ImageComposition\ArcAgent\arcInstallLog.txt` on the affected node(s) f
    Review the Arc agent install log on each affected node to confirm the lockdown error.
 
    ```powershell
-   Get-Content "C:\ImageComposition\ArcAgent\arcInstallLog.txt" | Select-String -Pattern "lock"
+   Get-Content "C:\ImageComposition\ArcAgent\arcInstallLog.txt" | Select-String -Pattern "lockdown"
    ```
 
 2. **Back up the locked log file**

--- a/TSG/Update/Update-fails-due-to-Arc-Agent-install-failure.md
+++ b/TSG/Update/Update-fails-due-to-Arc-Agent-install-failure.md
@@ -15,13 +15,15 @@
   </tr>
   <tr>
     <th style="text-align:left;">Affected Versions</th>
-    <td><strong>All versions</strong></td>
+    <td><strong>Arc Agent versions below 1.62</strong></td>
   </tr>
 </table>
 
 ## Overview
 
 Azure Local update may fail during Arc agent installation due to a file lockdown issue. The `azcmagent.log` file under `C:\ProgramData\AzureConnectedMachineAgent\Log` can become locked, preventing the Arc agent installer from completing successfully.
+
+> **Note:** This issue only affects Arc agent versions below 1.62. If you are running Arc agent 1.62 or later, this issue does not apply.
 
 ## Symptoms
 

--- a/TSG/Update/Update-fails-due-to-Arc-Agent-install-failure.md
+++ b/TSG/Update/Update-fails-due-to-Arc-Agent-install-failure.md
@@ -29,7 +29,7 @@ Run the following command on the affected node(s) to confirm the installed Arc A
 azcmagent version
 ```
 
-If the version is **1.62 or later**, this issue does not apply and you do not need to follow the steps below. If possible, upgrading the Arc Agent to version 1.62 or later is the recommended permanent fix for this issue.
+If the version is **1.62 or later**, this issue does not apply and you do not need to follow the steps below.
 
 ## Symptoms
 

--- a/TSG/Update/Update-fails-due-to-Arc-Agent-install-failure.md
+++ b/TSG/Update/Update-fails-due-to-Arc-Agent-install-failure.md
@@ -17,9 +17,19 @@
 
 ## Overview
 
-Azure Local update may fail during Arc agent installation due to a file lockdown issue. The `azcmagent.log` file under `C:\ProgramData\AzureConnectedMachineAgent\Log` can become locked, preventing the Arc agent installer from completing successfully.
+Azure Local update may fail during Arc agent installation due to a file locking issue. The Arc agent installer may encounter problems when trying to lock the existing `azcmagent.log` file under `C:\ProgramData\AzureConnectedMachineAgent\Log`, preventing it from completing successfully.
 
 > **Note:** This issue only affects Arc agent versions below 1.62. If you are running Arc agent 1.62 or later, this issue does not apply.
+
+### Check your Arc Agent version
+
+Run the following command on the affected node(s) to confirm the installed Arc Agent version:
+
+```powershell
+azcmagent version
+```
+
+If the version is **1.62 or later**, this issue does not apply and you do not need to follow the steps below. If possible, upgrading the Arc Agent to version 1.62 or later is the recommended permanent fix for this issue.
 
 ## Symptoms
 
@@ -50,20 +60,46 @@ Check `C:\ImageComposition\ArcAgent\arcInstallLog.txt` on the affected node(s) f
    Get-Content "C:\ImageComposition\ArcAgent\arcInstallLog.txt" | Select-String -Pattern "lockdown"
    ```
 
-2. **Back up the locked log file**
-   Move the `azcmagent.log` file to a backup location outside of the `C:\ProgramData\AzureConnectedMachineAgent` directory. This releases the lock and allows the installer to create a fresh log file.
+2. **Move the existing log file**
+   Move the `azcmagent.log` file to a backup location outside of the `C:\ProgramData\AzureConnectedMachineAgent` directory. This allows the Arc agent installer to create a fresh log file without encountering the locking issue.
 
    ```powershell
-   # Create a backup directory if it doesn't exist
-   New-Item -ItemType Directory -Path "C:\Temp\ArcAgentLogBackup" -Force
+   $ErrorActionPreference = "Stop"
 
-   # Move the locked log file to the backup location
-   Move-Item -Path "C:\ProgramData\AzureConnectedMachineAgent\Log\azcmagent.log" -Destination "C:\Temp\ArcAgentLogBackup\azcmagent.log" -Force
+   $sourceLogPath = "C:\ProgramData\AzureConnectedMachineAgent\Log\azcmagent.log"
+   $backupDirectory = "C:\Temp\ArcAgentLogBackup"
+   $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+   $nodeName = $env:COMPUTERNAME
+   $backupFileName = "azcmagent-$nodeName-$timestamp.log"
+   $destinationLogPath = Join-Path -Path $backupDirectory -ChildPath $backupFileName
+
+   # Verify the source log file exists
+   if (-not (Test-Path -Path $sourceLogPath)) {
+       throw "Source log file not found: $sourceLogPath"
+   }
+
+   # Create a backup directory if it doesn't exist
+   if (-not (Test-Path -Path $backupDirectory)) {
+       New-Item -ItemType Directory -Path $backupDirectory | Out-Null
+   }
+
+   # Verify the backup destination doesn't already exist
+   if (Test-Path -Path $destinationLogPath) {
+       throw "Backup destination already exists: $destinationLogPath"
+   }
+
+   # Move the log file to the backup location
+   Move-Item -Path $sourceLogPath -Destination $destinationLogPath
+
+   # Verify the move completed successfully
+   if ((-not (Test-Path -Path $destinationLogPath)) -or (Test-Path -Path $sourceLogPath)) {
+       throw "Backup verification failed. Source: $sourceLogPath Destination: $destinationLogPath"
+   }
    ```
 
    > **Note:** Repeat this step on all affected nodes in the cluster.
 
 3. **Retry the update**
-   Attempt the update again. The Arc agent installer should now be able to proceed without the lockdown issue.
+   Attempt the update again after the old log file has been moved. The Arc agent installer should now be able to proceed without the locking issue.
 
 ---

--- a/TSG/Update/Update-fails-due-to-Arc-Agent-install-failure.md
+++ b/TSG/Update/Update-fails-due-to-Arc-Agent-install-failure.md
@@ -63,40 +63,6 @@ Check `C:\ImageComposition\ArcAgent\arcInstallLog.txt` on the affected node(s) f
 2. **Move the existing log file**
    Move the `azcmagent.log` file to a backup location outside of the `C:\ProgramData\AzureConnectedMachineAgent` directory. This allows the Arc agent installer to create a fresh log file without encountering the locking issue.
 
-   ```powershell
-   $ErrorActionPreference = "Stop"
-
-   $sourceLogPath = "C:\ProgramData\AzureConnectedMachineAgent\Log\azcmagent.log"
-   $backupDirectory = "C:\Temp\ArcAgentLogBackup"
-   $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
-   $nodeName = $env:COMPUTERNAME
-   $backupFileName = "azcmagent-$nodeName-$timestamp.log"
-   $destinationLogPath = Join-Path -Path $backupDirectory -ChildPath $backupFileName
-
-   # Verify the source log file exists
-   if (-not (Test-Path -Path $sourceLogPath)) {
-       throw "Source log file not found: $sourceLogPath"
-   }
-
-   # Create a backup directory if it doesn't exist
-   if (-not (Test-Path -Path $backupDirectory)) {
-       New-Item -ItemType Directory -Path $backupDirectory | Out-Null
-   }
-
-   # Verify the backup destination doesn't already exist
-   if (Test-Path -Path $destinationLogPath) {
-       throw "Backup destination already exists: $destinationLogPath"
-   }
-
-   # Move the log file to the backup location
-   Move-Item -Path $sourceLogPath -Destination $destinationLogPath
-
-   # Verify the move completed successfully
-   if ((-not (Test-Path -Path $destinationLogPath)) -or (Test-Path -Path $sourceLogPath)) {
-       throw "Backup verification failed. Source: $sourceLogPath Destination: $destinationLogPath"
-   }
-   ```
-
    > **Note:** Repeat this step on all affected nodes in the cluster.
 
 3. **Retry the update**

--- a/TSG/Update/Update-fails-due-to-Arc-Agent-install-failure.md
+++ b/TSG/Update/Update-fails-due-to-Arc-Agent-install-failure.md
@@ -6,10 +6,6 @@
     <td><strong>Arc Agent</strong></td>
   </tr>
   <tr>
-    <th style="text-align:left; width: 180px;">Severity</th>
-    <td><strong>High</strong></td>
-  </tr>
-  <tr>
     <th style="text-align:left;">Applicable Scenarios</th>
     <td><strong>Update</strong></td>
   </tr>
@@ -30,7 +26,7 @@ Azure Local update may fail during Arc agent installation due to a file lockdown
 - Solution update fails during Arc agent installation step.
 - Arc agent install logs indicate a lockdown or file access issue.
 
-**Common error messages:**
+**Diagnosing the issue:**
 
 Check `C:\ImageComposition\ArcAgent\arcInstallLog.txt` on the affected node(s) for errors referencing a lockdown or inability to access the log file.
 
@@ -38,10 +34,6 @@ Check `C:\ImageComposition\ArcAgent\arcInstallLog.txt` on the affected node(s) f
 
 - Update does not progress past the Arc agent installation phase.
 - The `arcInstallLog.txt` file on one or more nodes contains lockdown-related errors.
-
-## Root Cause
-
-The Arc agent log file (`C:\ProgramData\AzureConnectedMachineAgent\Log\azcmagent.log`) becomes locked, which prevents the Arc agent installer from writing to it during the update process. This causes the installation to fail and blocks the overall update.
 
 ## Resolution
 
@@ -73,11 +65,5 @@ The Arc agent log file (`C:\ProgramData\AzureConnectedMachineAgent\Log\azcmagent
 
 3. **Retry the update**
    Attempt the update again. The Arc agent installer should now be able to proceed without the lockdown issue.
-
-4. **Verify resolution**
-   ```powershell
-   # Confirm the update is progressing past the Arc agent install step
-   Get-SolutionUpdate | Format-Table -Property Title, State, Status
-   ```
 
 ---


### PR DESCRIPTION
This pull request adds new troubleshooting guidance for update failures caused by Arc Agent installation issues due to a locked log file. It introduces a new TSG (Troubleshooting Guide) entry and updates the documentation index to reference this scenario.

**Documentation updates:**

* Added a new troubleshooting guide, `Update-fails-due-to-Arc-Agent-install-failure.md`, detailing symptoms, diagnosis, and resolution steps for update failures caused by a locked `azcmagent.log` file during Arc Agent installation (affecting versions below 1.62).
* Updated `README.md` to include a link to the new troubleshooting guide for easier discovery.