### PR TITLE
Add copilot-setup-steps.yml for full agentic PR reviews

### DIFF
--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -1,8 +1,2 @@
-name: "Copilot Setup Steps"
-on: workflow_dispatch
-
-jobs:
-  copilot-setup-steps:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+steps:
+  - uses: actions/checkout@v4

--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -1,0 +1,8 @@
+name: "Copilot Setup Steps"
+on: workflow_dispatch
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

Recent PRs show the warning:
> Copilot was unable to run its full agentic suite in this review.

This happens because the repo lacks a `.github/copilot-setup-steps.yml` file. Without it, Copilot Code Review cannot spin up a runner environment and falls back to limited static diff analysis.

## Fix

Add a minimal `copilot-setup-steps.yml` that checks out the repo. Since this is a docs-only repo (Markdown TSGs), no build tools or dependencies are needed — just a checkout gives Copilot full repo context for agentic reviews (cross-file references, link validation, structural analysis).

## References
- [Configuring runners for GitHub Copilot code review](https://docs.github.com/en/copilot/how-tos/copilot-on-github/set-up-copilot/configure-runners)
- Example of the warning: #287