### PR TITLE
docs: clarify DCBX is not used by Azure Local (#291)

### DIFF
--- a/TSG/Networking/Top-Of-Rack-Switch/Reference-TOR-QOS-Policy-Configuration.md
+++ b/TSG/Networking/Top-Of-Rack-Switch/Reference-TOR-QOS-Policy-Configuration.md
@@ -28,12 +28,18 @@ Implementing QoS is mandatory for Azure Local deployments that support Storage i
 
 | Setting                | Default Value                                      | Description                                                                                                       |
 | ---------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| DCBX                   | Enabled                                            | Data Center Bridging Exchange protocol is enabled for LLDP configuration notification only.                       |
 | Priority Flow Control  | Enabled                                            | PFC (IEEE 802.1Qbb) is enabled for lossless transport on storage traffic.                                         |
 | ETS (Bandwidth)        | Storage 50%<br>Cluster 1-2%<br>Default (Remainder) | Bandwidth reservations <br>Cluster Heartbeat:<br>2% if the adapter are <=10Gbps<br>1% if the adapter are >10 Gbps |
 | ECN                    | Enabled                                            | Explicit Congestion Notification is enabled for RDMA/Storage traffic.                                             |
 | VLAN                   | 711<br>712                                         | Default Storage Intent VLAN assignments. These values can be customized.                                          |
 | CoS (Class of Service) | Storage: 3<br>Cluster: 7<br>Default: 0             | Default CoS values for traffic classification.  These values can be customized.                                   |
+
+> [!IMPORTANT]
+> Azure Local does not configure DCBX. The host has no DCBX settings and does not send DCB TLVs back to the switch. DCB (PFC, ETS) is configured statically on both the host and the switch.
+>
+> On Cisco Nexus, the `send-tlv` option used with `priority-flow-control` typically requires DCBX to be enabled on the switch so the required TLVs can be advertised over LLDP (see [Azure Local Network Requirements][AzureLocalPhysicalNetworkRequirements]). When DCBX is enabled on the switch for this purpose, **DCBX willing mode must be False**. From Azure Local's perspective, the advertised TLVs are used for telemetry only — not for DCB negotiation.
+>
+> Dynamic changes to host-level DCB settings would disrupt RDMA traffic and impact the storage layer. This requirement has been in place since Storage Spaces Direct originally launched.
 
 > [!NOTE]
 > These defaults can be overridden using [Network ATC][NetworkAtc] custom settings. For more details, see [Manage Network ATC][NetworkAtcOverride].
@@ -246,7 +252,7 @@ interface Ethernet1/17
 
 In this example, the key points are the use of `priority-flow-control` and `service-policy`.
 
-- `priority-flow-control mode on send-tlv`: PFC (IEEE 802.1Qbb) allows you to pause traffic on specific CoS (Class of Service) lanes instead of pausing all traffic on the link. This is crucial for lossless Ethernet, especially for storage traffic (like RDMA), which is sensitive to packet loss.
+- `priority-flow-control mode on send-tlv`: Enables PFC (IEEE 802.1Qbb) on the interface and advertises the PFC TLV over LLDP. PFC allows you to pause traffic on specific CoS (Class of Service) lanes instead of pausing all traffic on the link, which is crucial for lossless Ethernet and storage traffic (like RDMA) that is sensitive to packet loss. On Cisco Nexus, enabling `send-tlv` typically requires DCBX to be enabled on the switch to advertise the TLVs. If DCBX is enabled, **willing mode must be False**. See the DCB note under [Azure Local Defaults](#azure-local-defaults) — Azure Local uses these TLVs for telemetry only and does not participate in DCBX negotiation.
 - `service-policy type qos input AZLocal_SERVICES`: Applies a QoS policy, which maps storage and cluster traffic to a specific CoS value that PFC will act upon.
 
 ## Terminology


### PR DESCRIPTION
Fixes #291

## Summary

Customer feedback (issue #291): the line "DCBX | Enabled | Data Center Bridging Exchange protocol is enabled for LLDP configuration notification only." led a customer to assume Azure Local participates in DCBX (and could be configured in willing mode). It does not.

This PR clarifies that:

- Azure Local does **not** configure DCBX. The host has zero DCBX configuration.
- DCB (PFC, ETS) is configured statically on **both the host and the switch**.
- On Cisco Nexus, `send-tlv` typically requires DCBX to be enabled on the switch so the required TLVs can be advertised over LLDP. When that's done, DCBX **willing mode must be False**.
- From Azure Local's perspective, advertised TLVs are used for **telemetry only**, not negotiation. The host never sends DCB TLVs back to the switch.
- This requirement has been in place since Storage Spaces Direct originally launched (dynamic DCB changes would disrupt RDMA and impact the storage layer).

## Changes

1. Removed the misleading `DCBX | Enabled | ...` row from the Azure Local Defaults table.
2. Added a `[!IMPORTANT]` callout below the defaults table explaining DCB vs. DCBX, `send-tlv` mechanics, and the willing-mode-False requirement.
3. Expanded the `priority-flow-control mode on send-tlv` bullet in the Cisco Nexus reference section to point back to the new callout.

## Notes

- No changes to actual switch configuration commands. Documentation only.
- Existing `[AzureLocalPhysicalNetworkRequirements]` link reference reused (no `?view=` query parameter).
- Lint errors visible in CI are all pre-existing (MD013 line length, MD033 inline `<br>` in tables). Repo has no `.markdownlint*` config and these patterns appear throughout the file. Did not touch unrelated lines.
