### PR TITLE
SystemDrive Free Space TSG: GMACache connectivity pointer + at-scale Tier 1 fan-out

### DIFF
--- a/TSG/EnvironmentValidator/Troubleshooting-Test-SystemDrive-Free-Space.md
+++ b/TSG/EnvironmentValidator/Troubleshooting-Test-SystemDrive-Free-Space.md
@@ -273,6 +273,21 @@ Remove-Item C:\Windows\Temp\* -Recurse -Force -ErrorAction SilentlyContinue
 Remove-Item $env:TEMP\* -Recurse -Force -ErrorAction SilentlyContinue
 ```
 
+**Run Tier 1 across all nodes at once.** For at-scale deployment prep, fan the Tier 1
+reclamation out to every machine in the cluster with a single `Invoke-Command` instead of
+repeating it node by node. For example, the WinSxS component cleanup (Tier 1a, the largest
+safe win):
+
+```powershell
+Invoke-Command -ComputerName (Get-ClusterNode).Name -ScriptBlock {
+    Dism.exe /Online /Cleanup-Image /StartComponentCleanup
+} | Out-Null
+```
+
+Wrap any of the Tier 1 a-d commands the same way. Do not fan out the Windows Update cache
+clear (Tier 1b) while a solution update or upgrade is in progress, because it briefly stops
+the `wuauserv` and BITS services on every node.
+
 #### Tier 2: diagnostic logs (reclaim with care)
 
 Large event logs such as `Microsoft-Windows-FailoverClustering%4Diagnostic` and
@@ -312,7 +327,12 @@ or updates, and it does not fix the underlying cause.
 - **`C:\GMACache` (monitoring agent cache).** A large `GMACache`, especially
   `GMACache\TelemetryCache`, usually means the machine cannot upload telemetry to
   Azure, so the data backs up on disk. The fix is to restore outbound connectivity
-  and the Arc connection so the cache drains on its own. Do not delete the cache to
+  and the Arc connection so the cache drains on its own. Concretely, that means
+  restoring the node's outbound HTTPS (TCP 443) to the Azure Arc and Azure Local
+  service endpoints (see the [Azure Local firewall and outbound connectivity
+  requirements](https://learn.microsoft.com/azure/azure-local/concepts/firewall-requirements))
+  and confirming the Arc agent is connected (`azcmagent show` reports
+  `Agent Status: Connected`). Do not delete the cache to
   free space; that loses buffered data, and the folder simply refills while
   connectivity is broken.
 - **`C:\Observability`, `C:\NugetStore`, `C:\ImageComposition`, `C:\CloudContent`,

--- a/TSG/EnvironmentValidator/Troubleshooting-Test-SystemDrive-Free-Space.md
+++ b/TSG/EnvironmentValidator/Troubleshooting-Test-SystemDrive-Free-Space.md
@@ -279,9 +279,13 @@ repeating it node by node. For example, the WinSxS component cleanup (Tier 1a, t
 safe win):
 
 ```powershell
-Invoke-Command -ComputerName (Get-ClusterNode).Name -ScriptBlock {
+# -ThrottleLimit caps how many nodes run this IO/CPU-intensive cleanup at once, so the
+# cluster does not spike all at once; the returned per-node exit code confirms success
+# (0 = succeeded). Raise the throttle only if the cluster has headroom.
+Invoke-Command -ComputerName (Get-ClusterNode).Name -ThrottleLimit 2 -ScriptBlock {
     Dism.exe /Online /Cleanup-Image /StartComponentCleanup
-} | Out-Null
+    [pscustomobject]@{ Node = $env:COMPUTERNAME; ExitCode = $LASTEXITCODE }
+} | Sort-Object Node | Format-Table -AutoSize
 ```
 
 Wrap any of the Tier 1 a-d commands the same way. Do not fan out the Windows Update cache
@@ -331,8 +335,8 @@ or updates, and it does not fix the underlying cause.
   restoring the node's outbound HTTPS (TCP 443) to the Azure Arc and Azure Local
   service endpoints (see the [Azure Local firewall and outbound connectivity
   requirements](https://learn.microsoft.com/azure/azure-local/concepts/firewall-requirements))
-  and confirming the Arc agent is connected (`azcmagent show` reports
-  `Agent Status: Connected`). Do not delete the cache to
+  and confirming the Arc agent is connected (`(azcmagent show -j | ConvertFrom-Json).status`
+  returns `Connected`). Do not delete the cache to
   free space; that loses buffered data, and the folder simply refills while
   connectivity is broken.
 - **`C:\Observability`, `C:\NugetStore`, `C:\ImageComposition`, `C:\CloudContent`,


### PR DESCRIPTION
Small follow-up to the merged **Test System Drive Free Space** TSG (#302), addressing two usability gaps:

- **GMACache connectivity, made actionable.** The Tier 3 note said to "restore outbound connectivity" for a backed-up `GMACache` but did not say which. It now names it: outbound HTTPS (TCP 443) to the Azure Arc and Azure Local service endpoints, links the [firewall and outbound connectivity requirements](https://learn.microsoft.com/azure/azure-local/concepts/firewall-requirements), and points at `azcmagent show` to confirm the Arc agent is connected. A network engineer can act on it without opening a second TSG.

- **At-scale Tier 1 fan-out.** Adds a note that the Tier 1 reclamation can be run across every machine in one `Invoke-Command -ComputerName (Get-ClusterNode).Name` (WinSxS example), instead of node by node, with the existing Tier 1b caveat (do not fan out the Windows Update cache clear while an update is in progress).

No change to the existing steps; these are additive. Lint: Grade A (structure, fences, relative links all pass).

INTERNAL USE ONLY -- findings must be independently validated before action.