### PR TITLE
Add merge=union driver for the Environment Validator TSG index

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Union-merge the Environment Validator TSG index. Many TSG PRs each add one entry
+# to this list in parallel; without a union driver they conflict on the same lines
+# even though the change is purely additive. `merge=union` keeps both sides' entries.
+TSG/EnvironmentValidator/README.md merge=union


### PR DESCRIPTION
## What

Adds a repo `.gitattributes` with the built-in `union` merge driver for the Environment Validator TSG index:

```
TSG/EnvironmentValidator/README.md merge=union
```

## Why

Many env-checker TSG PRs each append one link to `TSG/EnvironmentValidator/README.md` in parallel. These changes are purely additive, but without a merge driver git (and GitHub) report them as conflicts on the same list region, forcing PRs to be merged one-at-a-time with a merge-down each time, which under branch protection also dismisses approvals. The built-in `union` driver keeps both sides' entries, so index-only additions merge cleanly and in any order.

## Scope / safety

- Affects merge behavior for one file only (the EV index list). `union` simply keeps both sides' lines on an otherwise-conflicting hunk, which is exactly right for an append-only link index.
- No content change to any TSG.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
