### PR TITLE
Update Troubleshoot Outbound Connectivity TSG for AzStackHci.DiagnosticSettings v0.6.8

### DIFF
--- a/TSG/Networking/Arc-Gateway-Outbound-Connectivity/Troubleshoot-Outbound-Connectivity.md
+++ b/TSG/Networking/Arc-Gateway-Outbound-Connectivity/Troubleshoot-Outbound-Connectivity.md
@@ -175,6 +175,12 @@ Test-AzureLocalConnectivity -AzureRegion "EastUS" -OutputFormat CSV
 
 All output files are saved to: `C:\ProgramData\AzStackHci.DiagnosticSettings\`
 
+To copy the run's output files to an additional location (for example a network share), use the `-ExportPath` parameter. Files are still always saved to `C:\ProgramData\AzStackHci.DiagnosticSettings\` and copied to the specified path in addition:
+
+```PowerShell
+Test-AzureLocalConnectivity -AzureRegion "EastUS" -ExportPath "\\fileshare\AzureLocalDiagnostics"
+```
+
 Output files generated:
 
 | File | Description |
@@ -348,7 +354,13 @@ param (
     # version to nodes that are missing it or have a different version. Opt-in;
     # never mutates remote nodes silently. No PowerShell Gallery / internet
     # dependency (copies from the orchestrator's installed module folder).
-    [switch]$InstallMissingModuleOnNodes
+    [switch]$InstallMissingModuleOnNodes,
+
+    # Optional additional path to copy the report/transcript/JSON to. Results
+    # are ALWAYS saved to C:\ProgramData\AzStackHci.DiagnosticSettings; when a
+    # different path is specified the run folder is additionally copied there
+    # (never instead of ProgramData).
+    [string]$ExportPath = 'C:\ProgramData\AzStackHci.DiagnosticSettings'
 )
 ```
 
@@ -358,6 +370,7 @@ param (
 |--------|---------|
 | `-Scope` | **New in 0.6.7.** `Node` (default) tests the current node only; `Cluster` enumerates `Get-ClusterNode` and runs the test on every node via `Invoke-Command`, aggregating per-node results into a tabbed HTML report. |
 | `-InstallMissingModuleOnNodes` | **New in 0.6.7.** Only valid with `-Scope Cluster`. Side-loads the orchestrator's exact module version to nodes that are missing it or have a version mismatch (drift). Opt-in; no PowerShell Gallery / internet dependency. |
+| `-ExportPath` | **New in 0.6.7.** Optional additional folder to copy the report, transcript, and JSON to. Results are **always** saved to `C:\ProgramData\AzStackHci.DiagnosticSettings`; a different path is copied there *in addition*, never instead. |
 | `-Parallelism` | **New in 0.6.7.** Fans the Layer-7 sweep out across 1–16 process-isolated workers. Default `1` (sequential). Per-node default is `8` under `-Scope Cluster`. |
 | `-RequestMethod` | **New in 0.6.7.** `Auto` (default), `Get`, or `Head`. **Behaviour change:** the default is now `Auto` (HEAD-first with GET fallback). Use `-RequestMethod Get` to preserve pre-0.6.7 behaviour. |
 | `-PassThru` | **Enhanced in 0.6.7.** Node scope returns results with a per-row `ResultCategory` field and run-level summary properties; Cluster scope returns a cluster summary object. See [Programmatic use with -PassThru](#programmatic-use-with--passthru-automation). |

--- a/TSG/Networking/Arc-Gateway-Outbound-Connectivity/Troubleshoot-Outbound-Connectivity.md
+++ b/TSG/Networking/Arc-Gateway-Outbound-Connectivity/Troubleshoot-Outbound-Connectivity.md
@@ -1,10 +1,28 @@
 # Azure Local - Troubleshoot Outbound Network Connectivity
 
-> **TL;DR:** You can use the `Test-AzureLocalConnectivity` function from the **AzStackHci.DiagnosticSettings** module, to validate / troubleshoot outbound connectivity issues from Azure Local nodes to the required Azure endpoints.
+> **TL;DR:** You can use the `Test-AzureLocalConnectivity` function from the **AzStackHci.DiagnosticSettings** module, to validate / troubleshoot outbound connectivity issues from Azure Local nodes (_or any device or VM, such as pre-physical cluster deployment_) to the required Azure endpoints.
+
+## Contents
+
+- [Overview](#overview)
+- [Symptoms](#symptoms)
+- [Issue Validation](#issue-validation)
+- [Mitigation Details](#mitigation-details)
+- [Output format](#output-format)
+- [Programmatic use with `-PassThru` (automation)](#programmatic-use-with--passthru-automation)
+- [Share test results with Microsoft (Optional)](#share-test-results-with-microsoft-optional)
+- [Demo and example output](#demo-and-example-output)
+- [Parameter reference](#parameter-reference)
+- [Appendix](#appendix)
+- [How to get additional support](#how-to-get-additional-support)
 
 ## Overview
 
-Connected instances of Azure Local require outbound / egress network connectivity from the management network of each Azure Local instance to a list of public endpoints. Network connectivity to these endpoints is required for Azure Local to use Azure as a reliable management and control plane, such as for initial instance deployment, applying updates and for workload provisioning operational capabilities. Allowing connectivity to the list of endpoints is a prerequisite for deployment, but ongoing connectivity to the list of endpoints is vital for support, manageability and licensing compliance. The list of required endpoints varies depending on the customer scenario, for example the list of endpoints is reduced when using an Azure Arc Gateway, and varies (slightly) based on which Azure region is selected.
+Connected instances of Azure Local require outbound / egress network connectivity from the management network of each Azure Local instance to a list of public endpoints. This connectivity lets Azure Local use Azure as its management and control plane. In short:
+
+* **Required for day-one and day-two operations** — initial instance deployment, applying updates, and workload provisioning all depend on it.
+* **Ongoing connectivity is not optional** — it is vital for support, manageability, and licensing compliance, not just for the initial deployment.
+* **The endpoint list is scenario-specific** — it is reduced when using an Azure Arc Gateway, and varies (slightly) based on which Azure region is selected.
 
 For additional information on Azure Local Firewall requirements, please review - [Azure Local Firewall documentation](https://learn.microsoft.com/azure/azure-local/concepts/firewall-requirements).
 
@@ -40,7 +58,7 @@ Unlike the built-in readiness checks, which report an overall pass/fail, this fu
 * **Private Link / RFC1918 detection** — warns when an endpoint resolves to a private IP, helping distinguish intentional Private Link from a misconfiguration.
 * **Scenario-aware endpoint list** — automatically adjusts for Arc Gateway, Azure region, and your hardware OEM partner endpoints.
 
-> Note: This article documents version **0.6.8** of the module. Building on 0.6.7 (which added cluster-wide testing with `-Scope Cluster`, faster endpoint sweeps using HTTP HEAD requests via `-RequestMethod`, and parallel workers via `-Parallelism`), version 0.6.8 adds the `-ForceGitHubEndpointsUpdate` parameter (refresh the endpoint lists from GitHub while leaving the module untouched) and restructures `-PassThru` into a single, unified structured object (`SchemaVersion` `1.1`) whose per-endpoint rows are nested under a `.Results` property. See [Run tests across all cluster nodes](#run-tests-across-all-cluster-nodes--scope-cluster), [Faster testing: HEAD requests and parallel workers](#faster-testing-head-requests-and-parallel-workers), and [Programmatic use with -PassThru](#programmatic-use-with--passthru-automation) below.
+> Note: This article documents version **0.6.8** of the module. For the parameters added or changed in recent versions (including the 0.6.7 cluster / performance features and the 0.6.8 additions), see [Key parameter changes from previous versions](#key-parameter-changes-from-previous-versions).
 
 The 'Test-AzureLocalConnectivity' function has a dependency on the Azure Local Environment Checker module being installed, which is installed by default on all Azure Local physical machines. If Environment Checker module (_AzStackHci.EnvironmentChecker_) is not installed on the device running the connectivity test, you will be prompted to install the module first. The device used to install the AzStackHci.DiagnosticSettings module and test connectivity must have access to the PowerShell Gallery, in order to download the module (_nuget package_) to install it.
 
@@ -51,7 +69,8 @@ To install the AzStackHci.DiagnosticSettings module and perform connectivity tes
 ```PowerShell
 # Install the AzStackHci.DiagnosticSettings module, this can be on an Azure Local
 # physical machine (recommended), or any device inside your network (if it is using
-# the same firewall / proxy configuration as your Azure Local instance).
+# the same firewall / proxy configuration as your Azure Local instance). 
+# Answer "Y", to proceed with install.
 Install-Module -Name "AzStackHci.DiagnosticSettings" -Repository PSGallery
 
 # Test Azure Local Connectivity for a specific target Azure region.
@@ -293,7 +312,12 @@ The primary source of information is **opening the HTML output file** in a web b
 
 ![Test-AzureLocalConnectivity Demo](./images/Test-AzureLocalConnectivity_Demo.gif)
 
-### Test-AzureLocalConnectivity function parameters
+## Parameter reference
+
+The full parameter block is shown below for reference. You can also discover the same information at any time with `Get-Help Test-AzureLocalConnectivity -Full`.
+
+<details>
+<summary>Full parameter block (click to expand)</summary>
 
 ```PowerShell
 [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -396,6 +420,8 @@ param (
     [string]$ExportPath = 'C:\ProgramData\AzStackHci.DiagnosticSettings'
 )
 ```
+
+</details>
 
 ### Key parameter changes from previous versions
 

--- a/TSG/Networking/Arc-Gateway-Outbound-Connectivity/Troubleshoot-Outbound-Connectivity.md
+++ b/TSG/Networking/Arc-Gateway-Outbound-Connectivity/Troubleshoot-Outbound-Connectivity.md
@@ -40,7 +40,7 @@ Unlike the built-in readiness checks, which report an overall pass/fail, this fu
 * **Private Link / RFC1918 detection** — warns when an endpoint resolves to a private IP, helping distinguish intentional Private Link from a misconfiguration.
 * **Scenario-aware endpoint list** — automatically adjusts for Arc Gateway, Azure region, and your hardware OEM partner endpoints.
 
-> Note: This article documents version **0.6.7** of the module. Version 0.6.7 adds cluster-wide testing (`-Scope Cluster`), faster endpoint sweeps using HTTP HEAD requests (`-RequestMethod`) and parallel workers (`-Parallelism`), and richer `-PassThru` objects for automation. See [Run tests across all cluster nodes](#run-tests-across-all-cluster-nodes--scope-cluster), [Faster testing: HEAD requests and parallel workers](#faster-testing-head-requests-and-parallel-workers), and [Programmatic use with -PassThru](#programmatic-use-with--passthru-automation) below.
+> Note: This article documents version **0.6.8** of the module. Building on 0.6.7 (which added cluster-wide testing with `-Scope Cluster`, faster endpoint sweeps using HTTP HEAD requests via `-RequestMethod`, and parallel workers via `-Parallelism`), version 0.6.8 adds the `-ForceGitHubEndpointsUpdate` parameter (refresh the endpoint lists from GitHub while leaving the module untouched) and restructures `-PassThru` into a single, unified structured object (`SchemaVersion` `1.1`) whose per-endpoint rows are nested under a `.Results` property. See [Run tests across all cluster nodes](#run-tests-across-all-cluster-nodes--scope-cluster), [Faster testing: HEAD requests and parallel workers](#faster-testing-head-requests-and-parallel-workers), and [Programmatic use with -PassThru](#programmatic-use-with--passthru-automation) below.
 
 The 'Test-AzureLocalConnectivity' function has a dependency on the Azure Local Environment Checker module being installed, which is installed by default on all Azure Local physical machines. If Environment Checker module (_AzStackHci.EnvironmentChecker_) is not installed on the device running the connectivity test, you will be prompted to install the module first. The device used to install the AzStackHci.DiagnosticSettings module and test connectivity must have access to the PowerShell Gallery, in order to download the module (_nuget package_) to install it.
 
@@ -116,6 +116,22 @@ Hardware detection based on your hardware OEM vendor is built into the module au
 Test-AzureLocalConnectivity -AzureRegion "<AzureRegionName>" `
     -KeyVaultURL "https://<YourKeyVaultName>.vault.azure.net" `
     -IncludeOEMUrls "<YourOEMPartner>"
+```
+
+### Air-gapped and offline environments (`-NoAutoUpdate` and `-ForceGitHubEndpointsUpdate`)
+
+By default the function checks the PowerShell Gallery for a newer module version and downloads the latest endpoint lists from GitHub (`raw.githubusercontent.com`) before it runs. Two parameters control this behaviour for restricted or air-gapped environments:
+
+* **`-NoAutoUpdate`** skips the PowerShell Gallery update check **and** skips the GitHub endpoint download, using the cached endpoint files bundled with the module instead. Use this when no outbound calls to PSGallery or GitHub are permitted.
+* **`-ForceGitHubEndpointsUpdate`** forces the endpoint-list refresh from GitHub **even when `-NoAutoUpdate` is specified**. This decouples the endpoint refresh from the module update check, so you can leave the installed module untouched while still pulling the freshest endpoint list. It only has an effect together with `-NoAutoUpdate` (without it, the GitHub refresh is already attempted by default). If the download is blocked or fails, the run gracefully falls back to the cached endpoint files.
+
+```PowerShell
+# Leave the installed module untouched (no PSGallery check) but still refresh the
+# endpoint list from GitHub. Useful when raw GitHub content is allowed through the
+# firewall/proxy but the PowerShell Gallery is not.
+Test-AzureLocalConnectivity -AzureRegion "<AzureRegionName>" `
+    -NoAutoUpdate `
+    -ForceGitHubEndpointsUpdate
 ```
 
 ### Faster testing: HEAD requests and parallel workers
@@ -201,13 +217,13 @@ Output files generated:
 
 ## Programmatic use with `-PassThru` (automation)
 
-The `-PassThru` switch returns the test results to the PowerShell pipeline so you can act on them programmatically (for example, to fail a CI pipeline) without re-parsing the JSON report file. In v0.6.7 the returned objects were enhanced for automation.
+The `-PassThru` switch returns the test results to the PowerShell pipeline so you can act on them programmatically (for example, to fail a CI pipeline) without re-parsing the JSON report file. In v0.6.8 the returned value is a single **structured object** (`[pscustomobject]`) that matches the on-disk JSON summary (`SchemaVersion` `1.1`): all run-level fields are real properties on the object, and the per-endpoint rows are nested under a `.Results` property.
 
-> **Caller contract:** assign the result directly (`$results = Test-AzureLocalConnectivity ... -PassThru`). Do **not** wrap the call in `@( ... )` — doing so collapses the returned collection and breaks indexing and property access.
+> **Caller contract:** assign the result directly (`$results = Test-AzureLocalConnectivity ... -PassThru`). Access the per-endpoint rows through `$results.Results`. Because a single object is now returned, run-level properties survive `Where-Object` / `Select-Object` / `Sort-Object` on `.Results` (they no longer depend on note-properties bolted onto the results collection, as in 0.6.7).
 
 ### Node scope (`-Scope Node`, default)
 
-`-PassThru` returns the results collection. Each **row** now includes a `ResultCategory` field that classifies the outcome, so you no longer need to parse free-text notes to tell a genuine connectivity failure apart from a configuration gap:
+`-PassThru` returns the structured object described above. The per-endpoint rows are under `$results.Results`, and each **row** includes a `ResultCategory` field that classifies the outcome, so you no longer need to parse free-text notes to tell a genuine connectivity failure apart from a configuration gap:
 
 | `ResultCategory` | Meaning |
 |------------------|---------|
@@ -218,17 +234,17 @@ The `-PassThru` switch returns the test results to the PowerShell pipeline so yo
 | `PrivateLink` | Endpoint resolved to a private (RFC1918) address — possible Private Link configuration. |
 | `Skipped` | Endpoint was not tested (for example, skipped under Arc Gateway, or an untested wildcard placeholder). |
 
-The returned collection also carries run-level summary values as properties, including `RequestMethod`, `Parallelism`, `TotalDurationSeconds`, `Layer7WallClockSeconds`, `Layer7TotalDurationSeconds`, `Layer7TestedEndpoints`, `DownloadSpeed`, and the diagnostic state flags `SSLInspectionDetected` / `SSLInspectedURLs`, `PrivateLinkDetected` / `PrivateLinkCriticalArray` / `PrivateLinkProxyBypassArray`, and `CRLOfflineDetected` / `CRLOfflineURLs`.
+The object also carries run-level summary values as real properties, including `SchemaVersion`, `Hostname`, `Timestamp`, `AzureRegion`, `HardwareOEM`, `DownloadSpeed`, `ReportPath` / `JSONReportPath` (on-disk report locations), `RequestMethod`, `Parallelism`, `TotalDurationSeconds`, `Layer7WallClockSeconds`, `Layer7TotalDurationSeconds`, `Layer7TestedEndpoints`, the proxy fields (`ProxyEnabled`, `ProxyServer`, `ProxyHttp`, `ProxyHttps`, `ProxyBypassList`, `NoProxyList`), and the diagnostic state flags `SSLInspectionDetected` / `SSLInspectedURLs`, `PrivateLinkDetected` / `PrivateLinkCriticalArray` / `PrivateLinkProxyBypassArray` / `PrivateLinkDetectedArray` / `OtherRfc1918Count` / `PrivateLinkBypassConfirmedArray` / `PrivateLinkBypassMissingArray`, and `CRLOfflineDetected` / `CRLOfflineURLs`.
 
 ```PowerShell
 # Capture results and fail an automation run on any connectivity failure.
 $results = Test-AzureLocalConnectivity -AzureRegion "<AzureRegionName>" -NoOutput -PassThru
 
-# Per-row classification
-$results | Where-Object ResultCategory -eq 'ConnectivityFailure' |
+# Per-row classification (rows are under .Results)
+$results.Results | Where-Object ResultCategory -eq 'ConnectivityFailure' |
     Format-Table URL, Port, Layer7Status, ResultCategory -AutoSize
 
-# Run-level flags
+# Run-level flags (real properties on the returned object)
 if ($results.PrivateLinkCriticalArray.Count -gt 0) {
     throw "Arc endpoint(s) resolved to a private IP: $($results.PrivateLinkCriticalArray -join ', ')"
 }
@@ -236,28 +252,28 @@ if ($results.PrivateLinkCriticalArray.Count -gt 0) {
 
 ### Cluster scope (`-Scope Cluster`)
 
-With `-Scope Cluster -PassThru`, the function returns a single cluster summary object (`[pscustomobject]`) instead of a flat results collection. Key properties:
+With `-Scope Cluster -PassThru`, the function returns the **same unified structured object** as node scope, except the per-endpoint rows are grouped per node under a `.Nodes` array (each entry is itself a node-shaped structured object with its own `.Results` and run-level/detection fields). This gives you one consistent contract regardless of scope. Key top-level properties:
 
 | Property | Description |
 |----------|-------------|
+| `SchemaVersion` | Contract schema version (`1.1`). |
+| `Scope` | `Cluster`. |
 | `ClusterName` | Cluster name from `Get-Cluster`. |
 | `OrchestratorMachine` | Node that orchestrated the run. |
 | `RunGuid` | Unique identifier for the cluster run. |
 | `StartTime` / `EndTime` / `Duration` | Orchestration timing. |
-| `Nodes` | Hashtable keyed by node name; each value is that node's results collection. |
-| `NodeDurations` | Per-node test duration. |
-| `NodeDownloadSpeeds` | Per-node measured download speed. |
-| `NodeTelemetry` | Per-node run-level timing and `RequestMethod`. |
-| `Errors` | Per-node error messages (empty when the node succeeded). |
+| `ReportPath` / `JSONReportPath` | The **merged** cluster report and JSON on the orchestrator (local to the caller). |
 | `ExportPath` | Folder containing the cluster report and per-node output. |
+| `Nodes` | Array of per-node structured objects. Each entry carries `Hostname`, `Collected`, `Error`, `Results` (that node's per-endpoint rows), and the same run-level/detection fields as a node-scope run (per-node `ReportPath` / `JSONReportPath` point to files on the remote node). |
+| `Errors` | Per-node error messages (empty when the node succeeded). |
 
 ```PowerShell
 # Run a cluster test and inspect per-node results programmatically.
 $cluster = Test-AzureLocalConnectivity -AzureRegion "<AzureRegionName>" -Scope Cluster -PassThru
 
-foreach ($node in $cluster.Nodes.Keys) {
-    $failures = $cluster.Nodes[$node] | Where-Object ResultCategory -eq 'ConnectivityFailure'
-    Write-Host "$node : $($failures.Count) connectivity failure(s)"
+foreach ($node in $cluster.Nodes) {
+    $failures = $node.Results | Where-Object ResultCategory -eq 'ConnectivityFailure'
+    Write-Host "$($node.Hostname) : $($failures.Count) connectivity failure(s)"
 }
 ```
 
@@ -330,11 +346,18 @@ param (
     # before running. Default behaviour is notify-only (non-destructive).
     [switch]$AutoUpdate,
 
+    # Force downloading the latest endpoint lists from GitHub even when
+    # -NoAutoUpdate is specified. Only has an effect together with -NoAutoUpdate
+    # (the GitHub refresh is already attempted by default otherwise). Falls back
+    # to the cached endpoint files if the download is blocked or fails.
+    [switch]$ForceGitHubEndpointsUpdate,
+
     # Suppress all console output from the function.
     [switch]$NoOutput,
 
-    # Return the $Results object (Node scope) or the cluster summary object
-    # (Cluster scope) for further processing in PowerShell.
+    # Return the structured results object (Node scope) or the unified cluster
+    # structured object (Cluster scope) for further processing in PowerShell.
+    # Per-endpoint rows are under the .Results property (SchemaVersion 1.1).
     [switch]$PassThru,
 
     # Output report format. Default is HTML. CSV is also available.
@@ -383,8 +406,9 @@ param (
 | `-ExportPath` | **New in 0.6.7.** Optional additional folder to copy the report, transcript, and JSON to. Results are **always** saved to `C:\ProgramData\AzStackHci.DiagnosticSettings`; a different path is copied there *in addition*, never instead. |
 | `-Parallelism` | **New in 0.6.7.** Fans the Layer-7 sweep out across 1–16 process-isolated workers. Default `1` (sequential). Per-node default is `8` under `-Scope Cluster`. |
 | `-RequestMethod` | **New in 0.6.7.** `Auto` (default), `Get`, or `Head`. **Behaviour change:** the default is now `Auto` (HEAD-first with GET fallback). Use `-RequestMethod Get` to preserve pre-0.6.7 behaviour. |
-| `-PassThru` | **Enhanced in 0.6.7.** Node scope returns results with a per-row `ResultCategory` field and run-level summary properties; Cluster scope returns a cluster summary object. See [Programmatic use with -PassThru](#programmatic-use-with--passthru-automation). |
+| `-PassThru` | **Restructured in 0.6.8.** Now returns a single structured object (`SchemaVersion` `1.1`) with run-level fields as real properties and per-endpoint rows under `.Results`. Node scope and Cluster scope share one contract; in Cluster scope the per-node objects are nested under a `.Nodes` array. See [Programmatic use with -PassThru](#programmatic-use-with--passthru-automation). |
 | `-AutoUpdate` | **New in 0.6.7.** Opt in to auto-installing a newer module version from PowerShell Gallery. Default is notify-only (non-destructive). |
+| `-ForceGitHubEndpointsUpdate` | **New in 0.6.8.** Forces the endpoint-list refresh from GitHub even when `-NoAutoUpdate` is specified, leaving the installed module untouched. Only meaningful together with `-NoAutoUpdate`; falls back to cached endpoint files if the download is blocked. |
 | `-ArcGatewayDeployment` and `-ArcGatewayURL` | Now a **mandatory parameter set** — both must be specified together. Previously they were independent optional parameters. |
 | `-OutputFormat` | Controls the report format: `HTML` (default) or `CSV`. JSON is always generated alongside. |
 | `-IncludeOEMUrls` | Allows testing OEM hardware partner specific endpoints (DataOn, Dell, HPE, Hitachi, Lenovo, or TestAll). |

--- a/TSG/Networking/Arc-Gateway-Outbound-Connectivity/Troubleshoot-Outbound-Connectivity.md
+++ b/TSG/Networking/Arc-Gateway-Outbound-Connectivity/Troubleshoot-Outbound-Connectivity.md
@@ -30,6 +30,8 @@ If you are finding it difficult to isolate the cause of the network related issu
 
 To help with troubleshooting or root causing network connectivity issues, you can use the **Test-AzureLocalConnectivity** function which is included in the **AzStackHCI.DiagnosticSettings** module. This function can help automate testing that connectivity is working correctly from Azure Local physical machines to the required public endpoints. The function supports Arc Gateway scenarios and has an `-AzureRegion` parameter to allow testing against a specific Azure region that matches your Azure Local instance deployment.
 
+> Note: This article documents version **0.6.7** of the module. Version 0.6.7 adds cluster-wide testing (`-Scope Cluster`), faster endpoint sweeps using HTTP HEAD requests (`-RequestMethod`) and parallel workers (`-Parallelism`), and richer `-PassThru` objects for automation. See [Run tests across all cluster nodes](#run-tests-across-all-cluster-nodes--scope-cluster), [Faster testing: HEAD requests and parallel workers](#faster-testing-head-requests-and-parallel-workers), and [Programmatic use with -PassThru](#programmatic-use-with--passthru-automation) below.
+
 The 'Test-AzureLocalConnectivity' function has a dependency on the Azure Local Environment Checker module being installed, which is installed by default on all Azure Local physical machines. If Environment Checker module (_AzStackHci.EnvironmentChecker_) is not installed on the device running the connectivity test, you will be prompted to install the module first. The device used to install the AzStackHCI.DiagnosticSettings module and test connectivity must have access to the PowerShell Gallery, in order to download the module (_nuget package_) to install it.
 
 ### Install and run connectivity tests
@@ -51,6 +53,33 @@ Test-AzureLocalConnectivity -AzureRegion "<AzureRegionName>" -KeyVaultURL "https
 # function above, which will output full diagnostic level responses from the remote
 # endpoint web server.
 # The output from the function is automatically saved in the PowerShell transcript.
+```
+
+### Run tests across all cluster nodes (`-Scope Cluster`)
+
+By default the function tests connectivity from the **current node only** (`-Scope Node`). When you run the command from a node that is a member of an active Azure Local (failover) cluster, you can add `-Scope Cluster` to enumerate every cluster node and run the same connectivity test on each node, then aggregate the per-node results into a single tabbed HTML report.
+
+Cluster mode requirements:
+
+* The **AzStackHci.DiagnosticSettings** module must be installed (at the same version) on every cluster node. If a node is missing the module or has a different version, the run fails fast and lists the affected nodes — unless you add `-InstallMissingModuleOnNodes` (see below).
+* Standard Kerberos / `Invoke-Command` remoting is used (no CredSSP or TrustedHosts changes are required).
+* The orchestrating session must be elevated (Administrator) and have remote access to every node.
+
+```PowerShell
+# Run the connectivity test on every node in the cluster and produce a
+# single, tabbed cluster HTML report.
+# /// ACTION: Update <AzureRegionName> to match your Azure Region.
+Test-AzureLocalConnectivity -AzureRegion "<AzureRegionName>" -Scope Cluster
+```
+
+Each node runs its own Layer-7 sweep in parallel (per-node default `-Parallelism 8`), so the orchestrator only holds one lightweight remoting job per node. To automatically copy (side-load) the orchestrator's exact module version to any node that is missing it or has a different version, add `-InstallMissingModuleOnNodes`. This is opt-in by design (it never modifies remote nodes silently) and copies from the orchestrator's installed module folder, so it does **not** require PowerShell Gallery or internet access on the nodes:
+
+```PowerShell
+# Cluster test, automatically side-loading the orchestrator's module version
+# to any node that is missing it or has a version mismatch (drift).
+Test-AzureLocalConnectivity -AzureRegion "<AzureRegionName>" `
+    -Scope Cluster `
+    -InstallMissingModuleOnNodes
 ```
 
 ### Arc Gateway deployments
@@ -78,6 +107,26 @@ Test-AzureLocalConnectivity -AzureRegion "<AzureRegionName>" `
     -KeyVaultURL "https://<YourKeyVaultName>.vault.azure.net" `
     -IncludeOEMUrls "<YourOEMPartner>"
 ```
+
+### Faster testing: HEAD requests and parallel workers
+
+Two parameters can reduce the wall-clock time of a full endpoint sweep:
+
+* **`-RequestMethod`** controls the HTTP method used to test each endpoint:
+  * `Auto` (**default**) — try an HTTP `HEAD` request first (status line and headers only, no body download) and automatically fall back to `GET` for any endpoint that rejects or under-answers `HEAD` (for example a `405 Method Not Allowed`, `400 Bad Request`, or an ambiguous `403`). This gives the speed of `HEAD` with `GET` as a safety net.
+  * `Get` — always use `GET` (full body download). This preserves the behaviour of versions prior to 0.6.7 and is useful for baseline comparisons.
+  * `Head` — always use `HEAD` with no fallback. Fastest, but some endpoints (certain storage SAS URLs and CDN edge nodes) respond differently to `HEAD` than `GET`.
+* **`-Parallelism`** (1–16, default `1`) fans the Layer-7 endpoint sweep out across that many process-isolated background workers. At `1` the test runs sequentially (identical to earlier behaviour). With `-Scope Cluster`, each node uses a per-node default of `8`.
+
+```PowerShell
+# Faster sweep: HEAD-first with GET fallback (default) and 8 parallel workers.
+Test-AzureLocalConnectivity -AzureRegion "<AzureRegionName>" -Parallelism 8
+
+# Preserve pre-0.6.7 behaviour (GET only, sequential).
+Test-AzureLocalConnectivity -AzureRegion "<AzureRegionName>" -RequestMethod Get -Parallelism 1
+```
+
+Output ordering is preserved regardless of `-Parallelism` (results are re-sorted before the report is written), so the report contents are comparable between sequential and parallel runs.
 
 ### Supported Azure regions
 
@@ -133,6 +182,68 @@ Output files generated:
 | `AzureLocal_ConnectivityTest_<Region>_<Hostname>_<DateTime>.html` | HTML report (default) or `.csv` if `-OutputFormat CSV` is used |
 | `AzureLocal_ConnectivityTest_<Region>_<Hostname>_<DateTime>.json` | JSON test results with summary metadata (always generated) |
 | `Transcript_AzureLocal_ConnectivityTest_<Region>_<Hostname>_<DateTime>.log` | PowerShell transcript log |
+
+## Programmatic use with `-PassThru` (automation)
+
+The `-PassThru` switch returns the test results to the PowerShell pipeline so you can act on them programmatically (for example, to fail a CI pipeline) without re-parsing the JSON report file. In v0.6.7 the returned objects were enhanced for automation.
+
+> **Caller contract:** assign the result directly (`$results = Test-AzureLocalConnectivity ... -PassThru`). Do **not** wrap the call in `@( ... )` — doing so collapses the returned collection and breaks indexing and property access.
+
+### Node scope (`-Scope Node`, default)
+
+`-PassThru` returns the results collection. Each **row** now includes a `ResultCategory` field that classifies the outcome, so you no longer need to parse free-text notes to tell a genuine connectivity failure apart from a configuration gap:
+
+| `ResultCategory` | Meaning |
+|------------------|---------|
+| `Success` | Endpoint reachable. |
+| `ConnectivityFailure` | Endpoint could not be reached (DNS / TCP / Layer-7 failure). |
+| `ConfigGap` | A required parameter was not supplied (for example `-KeyVaultURL` left unsubstituted) — a setup issue, not a blocked endpoint. |
+| `SSLInspected` | SSL/TLS inspection was detected on the path to the endpoint. |
+| `PrivateLink` | Endpoint resolved to a private (RFC1918) address — possible Private Link configuration. |
+| `Skipped` | Endpoint was not tested (for example, skipped under Arc Gateway, or an untested wildcard placeholder). |
+
+The returned collection also carries run-level summary values as properties, including `RequestMethod`, `Parallelism`, `TotalDurationSeconds`, `Layer7WallClockSeconds`, `Layer7TotalDurationSeconds`, `Layer7TestedEndpoints`, `DownloadSpeed`, and the diagnostic state flags `SSLInspectionDetected` / `SSLInspectedURLs`, `PrivateLinkDetected` / `PrivateLinkCriticalArray` / `PrivateLinkProxyBypassArray`, and `CRLOfflineDetected` / `CRLOfflineURLs`.
+
+```PowerShell
+# Capture results and fail an automation run on any connectivity failure.
+$results = Test-AzureLocalConnectivity -AzureRegion "<AzureRegionName>" -NoOutput -PassThru
+
+# Per-row classification
+$results | Where-Object ResultCategory -eq 'ConnectivityFailure' |
+    Format-Table URL, Port, Layer7Status, ResultCategory -AutoSize
+
+# Run-level flags
+if ($results.PrivateLinkCriticalArray.Count -gt 0) {
+    throw "Arc endpoint(s) resolved to a private IP: $($results.PrivateLinkCriticalArray -join ', ')"
+}
+```
+
+### Cluster scope (`-Scope Cluster`)
+
+With `-Scope Cluster -PassThru`, the function returns a single cluster summary object (`[pscustomobject]`) instead of a flat results collection. Key properties:
+
+| Property | Description |
+|----------|-------------|
+| `ClusterName` | Cluster name from `Get-Cluster`. |
+| `OrchestratorMachine` | Node that orchestrated the run. |
+| `RunGuid` | Unique identifier for the cluster run. |
+| `StartTime` / `EndTime` / `Duration` | Orchestration timing. |
+| `Nodes` | Hashtable keyed by node name; each value is that node's results collection. |
+| `NodeDurations` | Per-node test duration. |
+| `NodeDownloadSpeeds` | Per-node measured download speed. |
+| `NodeTelemetry` | Per-node run-level timing and `RequestMethod`. |
+| `Errors` | Per-node error messages (empty when the node succeeded). |
+| `ExportPath` | Folder containing the cluster report and per-node output. |
+
+```PowerShell
+# Run a cluster test and inspect per-node results programmatically.
+$cluster = Test-AzureLocalConnectivity -AzureRegion "<AzureRegionName>" -Scope Cluster -PassThru
+
+foreach ($node in $cluster.Nodes.Keys) {
+    $failures = $cluster.Nodes[$node] | Where-Object ResultCategory -eq 'ConnectivityFailure'
+    Write-Host "$node : $($failures.Count) connectivity failure(s)"
+}
+```
 
 ## Share test results with Microsoft (Optional)
 
@@ -194,19 +305,50 @@ param (
     # Valid values: DataOn, Dell, HPE, Hitachi, Lenovo, TestAll
     [string]$IncludeOEMUrls,
 
-    # Skip automatic module version check against PowerShell Gallery.
+    # Skip the PowerShell Gallery update check AND skip downloading endpoint
+    # lists from GitHub (uses cached endpoint files bundled with the module).
+    # Use in air-gapped environments or CI pipelines.
     [switch]$NoAutoUpdate,
+
+    # Opt in to auto-installing a newer module version from PowerShell Gallery
+    # before running. Default behaviour is notify-only (non-destructive).
+    [switch]$AutoUpdate,
 
     # Suppress all console output from the function.
     [switch]$NoOutput,
 
-    # Return the $Results array object for further processing in PowerShell.
+    # Return the $Results object (Node scope) or the cluster summary object
+    # (Cluster scope) for further processing in PowerShell.
     [switch]$PassThru,
 
     # Output report format. Default is HTML. CSV is also available.
     # JSON is always generated in addition to the selected format.
     [ValidateSet('HTML', 'CSV')]
-    [string]$OutputFormat = 'HTML'
+    [string]$OutputFormat = 'HTML',
+
+    # HTTP request method for each endpoint test.
+    #   'Auto' (default) - HEAD first, GET fallback on 405/400/ambiguous response.
+    #   'Get'  - GET only (pre-0.6.7 byte-identical behaviour).
+    #   'Head' - HEAD only, no fallback (fastest; some endpoints reject HEAD).
+    [ValidateSet('Get', 'Head', 'Auto')]
+    [string]$RequestMethod = 'Auto',
+
+    # Number of parallel workers for the Layer-7 endpoint sweep (1-16).
+    # Default 1 (sequential). With -Scope Cluster the per-node default is 8.
+    [ValidateRange(1, 16)]
+    [int]$Parallelism = 1,
+
+    # Test scope. 'Node' (default) tests the current node only. 'Cluster'
+    # enumerates Get-ClusterNode and runs the test on every node, aggregating
+    # the per-node results into a tabbed HTML report.
+    [ValidateSet('Node', 'Cluster')]
+    [string]$Scope = 'Node',
+
+    # Only valid with -Scope Cluster. Side-load the orchestrator's exact module
+    # version to nodes that are missing it or have a different version. Opt-in;
+    # never mutates remote nodes silently. No PowerShell Gallery / internet
+    # dependency (copies from the orchestrator's installed module folder).
+    [switch]$InstallMissingModuleOnNodes
 )
 ```
 
@@ -214,16 +356,22 @@ param (
 
 | Change | Details |
 |--------|---------|
+| `-Scope` | **New in 0.6.7.** `Node` (default) tests the current node only; `Cluster` enumerates `Get-ClusterNode` and runs the test on every node via `Invoke-Command`, aggregating per-node results into a tabbed HTML report. |
+| `-InstallMissingModuleOnNodes` | **New in 0.6.7.** Only valid with `-Scope Cluster`. Side-loads the orchestrator's exact module version to nodes that are missing it or have a version mismatch (drift). Opt-in; no PowerShell Gallery / internet dependency. |
+| `-Parallelism` | **New in 0.6.7.** Fans the Layer-7 sweep out across 1–16 process-isolated workers. Default `1` (sequential). Per-node default is `8` under `-Scope Cluster`. |
+| `-RequestMethod` | **New in 0.6.7.** `Auto` (default), `Get`, or `Head`. **Behaviour change:** the default is now `Auto` (HEAD-first with GET fallback). Use `-RequestMethod Get` to preserve pre-0.6.7 behaviour. |
+| `-PassThru` | **Enhanced in 0.6.7.** Node scope returns results with a per-row `ResultCategory` field and run-level summary properties; Cluster scope returns a cluster summary object. See [Programmatic use with -PassThru](#programmatic-use-with--passthru-automation). |
+| `-AutoUpdate` | **New in 0.6.7.** Opt in to auto-installing a newer module version from PowerShell Gallery. Default is notify-only (non-destructive). |
 | `-ArcGatewayDeployment` and `-ArcGatewayURL` | Now a **mandatory parameter set** — both must be specified together. Previously they were independent optional parameters. |
-| `-OutputFormat` | **New parameter.** Controls the report format: `HTML` (default) or `CSV`. JSON is always generated alongside. |
-| `-IncludeOEMUrls` | **New parameter.** Allows testing OEM hardware partner specific endpoints (DataOn, Dell, HPE, Hitachi, Lenovo, or TestAll). |
-| `-NoAutoUpdate` | **New parameter.** Skips automatic version check against PowerShell Gallery. |
-| `-NoOutput` | **New parameter.** Suppresses all console output for automation/scripting scenarios. |
-| `USGovVirginia` | **New Azure region** added to the `-AzureRegion` validated set. |
-| HTML output | **Default output format changed** from CSV to HTML with color-coded rows and summary section. |
+| `-OutputFormat` | Controls the report format: `HTML` (default) or `CSV`. JSON is always generated alongside. |
+| `-IncludeOEMUrls` | Allows testing OEM hardware partner specific endpoints (DataOn, Dell, HPE, Hitachi, Lenovo, or TestAll). |
+| `-NoAutoUpdate` | Skips the PowerShell Gallery update check **and** skips downloading endpoint lists from GitHub (uses cached endpoint files). Use in air-gapped environments. |
+| `-NoOutput` | Suppresses all console output for automation/scripting scenarios. |
+| `USGovVirginia` | Azure region included in the `-AzureRegion` validated set. |
+| HTML output | Default output format is HTML with color-coded rows and summary section. |
 | JSON output | **Always generated** alongside the primary report format. |
-| Download speed test | Now uses **parallel multi-session downloads** for more accurate bandwidth measurement. |
-| Private Link detection | **New feature.** Detects and warns if endpoints resolve to RFC1918 private IP addresses (possible Private Link configuration). |
+| Download speed test | Uses **parallel multi-session downloads** for more accurate bandwidth measurement. |
+| Private Link detection | Detects and warns if endpoints resolve to RFC1918 private IP addresses (possible Private Link configuration). |
 
 ## Appendix
 

--- a/TSG/Networking/Arc-Gateway-Outbound-Connectivity/Troubleshoot-Outbound-Connectivity.md
+++ b/TSG/Networking/Arc-Gateway-Outbound-Connectivity/Troubleshoot-Outbound-Connectivity.md
@@ -1,5 +1,7 @@
 # Azure Local - Troubleshoot Outbound Network Connectivity
 
+> **TL;DR:** Run `Test-AzureLocalConnectivity` from the **AzStackHci.DiagnosticSettings** module to validate (and pinpoint) outbound connectivity from your Azure Local nodes to the required Azure endpoints.
+
 ## Overview
 
 Connected instances of Azure Local require outbound / egress network connectivity from the management network of each Azure Local instance to a list of public endpoints. Network connectivity to these endpoints is required for Azure Local to use Azure as a reliable management and control plane, such as for initial instance deployment, applying updates and for workload provisioning operational capabilities. Allowing connectivity to the list of endpoints is a prerequisite for deployment, but ongoing connectivity to the list of endpoints is vital for support, manageability and licensing compliance. The list of required endpoints varies depending on the customer scenario, for example the list of endpoints is reduced when using an Azure Arc Gateway, and varies (slightly) based on which Azure region is selected.

--- a/TSG/Networking/Arc-Gateway-Outbound-Connectivity/Troubleshoot-Outbound-Connectivity.md
+++ b/TSG/Networking/Arc-Gateway-Outbound-Connectivity/Troubleshoot-Outbound-Connectivity.md
@@ -16,7 +16,8 @@ There are several symptoms or issues that will occur if the required endpoints a
 1. Physical machines show their "Azure Arc" status as "Disconnected" in Azure portal experience (_Arc agent not connected_).
 1. Deployment of new Azure Local VMs fails with RPC failure in Azure portal as the ARM deployment status.
 1. Updates fail at "update ARB and extensions" step with "SSL: CERTIFICATE_VERIFY_FAILED" shown in Azure portal update blade.
-1. There are many other network related issues that could occur when the required endpoints are not accessible from the management (_physical machines and ARB_) network address space.
+
+Many other network related issues can also occur when the required endpoints are not accessible from the management (_physical machines and ARB_) network address space.
 
 ## Issue Validation
 
@@ -28,18 +29,25 @@ If you are finding it difficult to isolate the cause of the network related issu
 
 ## Mitigation Details
 
-To help with troubleshooting or root causing network connectivity issues, you can use the **Test-AzureLocalConnectivity** function which is included in the **AzStackHCI.DiagnosticSettings** module. This function can help automate testing that connectivity is working correctly from Azure Local physical machines to the required public endpoints. The function supports Arc Gateway scenarios and has an `-AzureRegion` parameter to allow testing against a specific Azure region that matches your Azure Local instance deployment.
+To help with troubleshooting or root causing network connectivity issues, you can use the **Test-AzureLocalConnectivity** function which is included in the **AzStackHci.DiagnosticSettings** module. This function is intended for operators and Customer Service and Support (CSS) engineers, either to validate connectivity before deployment or to isolate a blocked firewall/proxy endpoint during active troubleshooting. It automates testing that connectivity is working correctly from Azure Local physical machines to the required public endpoints. The function supports Arc Gateway scenarios and has an `-AzureRegion` parameter to allow testing against a specific Azure region that matches your Azure Local instance deployment.
+
+Unlike the built-in readiness checks, which report an overall pass/fail, this function gives deeper per-endpoint diagnostics that are useful when isolating a blocked or intercepted endpoint:
+
+* **Per-endpoint results** — every required URL is tested individually for DNS, TCP, and Layer-7 (HTTP/HTTPS) reachability, so you can pinpoint exactly which endpoint is blocked.
+* **SSL inspection detection** — flags endpoints where the certificate was substituted by a proxy, the typical cause of `SSL: CERTIFICATE_VERIFY_FAILED`, and captures the leaf/intermediate/root certificate chain.
+* **Private Link / RFC1918 detection** — warns when an endpoint resolves to a private IP, helping distinguish intentional Private Link from a misconfiguration.
+* **Scenario-aware endpoint list** — automatically adjusts for Arc Gateway, Azure region, and your hardware OEM partner endpoints.
 
 > Note: This article documents version **0.6.7** of the module. Version 0.6.7 adds cluster-wide testing (`-Scope Cluster`), faster endpoint sweeps using HTTP HEAD requests (`-RequestMethod`) and parallel workers (`-Parallelism`), and richer `-PassThru` objects for automation. See [Run tests across all cluster nodes](#run-tests-across-all-cluster-nodes--scope-cluster), [Faster testing: HEAD requests and parallel workers](#faster-testing-head-requests-and-parallel-workers), and [Programmatic use with -PassThru](#programmatic-use-with--passthru-automation) below.
 
-The 'Test-AzureLocalConnectivity' function has a dependency on the Azure Local Environment Checker module being installed, which is installed by default on all Azure Local physical machines. If Environment Checker module (_AzStackHci.EnvironmentChecker_) is not installed on the device running the connectivity test, you will be prompted to install the module first. The device used to install the AzStackHCI.DiagnosticSettings module and test connectivity must have access to the PowerShell Gallery, in order to download the module (_nuget package_) to install it.
+The 'Test-AzureLocalConnectivity' function has a dependency on the Azure Local Environment Checker module being installed, which is installed by default on all Azure Local physical machines. If Environment Checker module (_AzStackHci.EnvironmentChecker_) is not installed on the device running the connectivity test, you will be prompted to install the module first. The device used to install the AzStackHci.DiagnosticSettings module and test connectivity must have access to the PowerShell Gallery, in order to download the module (_nuget package_) to install it.
 
 ### Install and run connectivity tests
 
-To install the AzStackHCI.DiagnosticSettings module and perform connectivity tests for a support or troubleshooting scenario, use the commands below:
+To install the AzStackHci.DiagnosticSettings module and perform connectivity tests for a support or troubleshooting scenario, use the commands below:
 
 ```PowerShell
-# Install the AzStackHCI.DiagnosticSettings module, this can be on an Azure Local
+# Install the AzStackHci.DiagnosticSettings module, this can be on an Azure Local
 # physical machine (recommended), or any device inside your network (if it is using
 # the same firewall / proxy configuration as your Azure Local instance).
 Install-Module -Name "AzStackHci.DiagnosticSettings" -Repository PSGallery

--- a/TSG/Networking/Arc-Gateway-Outbound-Connectivity/Troubleshoot-Outbound-Connectivity.md
+++ b/TSG/Networking/Arc-Gateway-Outbound-Connectivity/Troubleshoot-Outbound-Connectivity.md
@@ -1,6 +1,6 @@
 # Azure Local - Troubleshoot Outbound Network Connectivity
 
-> **TL;DR:** Run `Test-AzureLocalConnectivity` from the **AzStackHci.DiagnosticSettings** module to validate (and pinpoint) outbound connectivity from your Azure Local nodes to the required Azure endpoints.
+> **TL;DR:** You can use the `Test-AzureLocalConnectivity` function from the **AzStackHci.DiagnosticSettings** module, to validate / troubleshoot outbound connectivity issues from Azure Local nodes to the required Azure endpoints.
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Updates the **Troubleshoot Outbound Network Connectivity** TSG to document `Test-AzureLocalConnectivity` from the **AzStackHci.DiagnosticSettings** module at version **0.6.8**, and improves the article's readability and navigation.

This is a **documentation-only** change touching a single file:
`TSG/Networking/Arc-Gateway-Outbound-Connectivity/Troubleshoot-Outbound-Connectivity.md`

## What changed

### Content updates for module v0.6.8

- Documented the new **`-ForceGitHubEndpointsUpdate`** switch (refresh the endpoint list from GitHub while leaving the installed module untouched; only meaningful alongside `-NoAutoUpdate`), including a new "Air-gapped and offline environments" subsection.
- Rewrote the **`-PassThru`** section for the restructured v0.6.8 contract: a single, unified structured object (`SchemaVersion` `1.1`) with run-level fields as real properties and per-endpoint rows nested under `.Results`. Updated the caller contract, node-scope example (`$results.Results | ...`), the run-level property list, and the cluster-scope section (per-node objects are now under a `.Nodes` array rather than a hashtable).
- Updated the version note and the "Key parameter changes from previous versions" table (added `-ForceGitHubEndpointsUpdate`; marked `-PassThru` as restructured in 0.6.8).

### Readability and structure

- Added a **Table of Contents**.
- Tightened the **Overview** into a short intro plus scannable bullets.
- Moved the full parameter block into a dedicated **Parameter reference** section inside a collapsible `<details>` block (with a pointer to `Get-Help Test-AzureLocalConnectivity -Full`).
- Reduced version-history duplication by pointing to the changes table as the single source of truth.

## Notes

- Documentation only — no code or script changes.
- All external links point to `learn.microsoft.com` without a release/version query string, per the repo link guidelines.
