### PR TITLE
Forge and standardize public TSG templates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -135,8 +135,8 @@ Technical grade records the TSG outcome, not the cluster outcome:
 | C | Incomplete validation, fallback-only validation, missing required routing metadata, or unclear automation readiness |
 | F | A structural, safety, metadata, or command defect that must block publishing |
 
-Validation depth (static-only through scratch-object reproduction) is recorded separately in
-`fidelity_level` (L0 to L3), not in the grade.
+Validation depth (static-only through a full live inject-detect-mitigate loop) is recorded
+separately in `fidelity_level` (L0 to L4), not in the grade.
 
 Automation status is separate from execution surface:
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -130,10 +130,13 @@ Technical grade records the TSG outcome, not the cluster outcome:
 | Grade | Meaning |
 | --- | --- |
 | `null` | No TSG-FORGE technical grade has been established |
-| A | The detector, discoverability, documented mitigation, and revalidation passed |
-| B | The live loop passed, but documented discoverability is incomplete |
-| C | Recovery required fallback automation or the failure detail was not actionable |
-| F | The bad state was not detected or the documented mitigation did not restore service |
+| A | The article is complete for its type, safety gates are present, metadata is valid, links resolve, and lint is clean |
+| B | Usable, but non-blocking gaps remain, such as missing optional evidence or a documented false-positive warning |
+| C | Incomplete validation, fallback-only validation, missing required routing metadata, or unclear automation readiness |
+| F | A structural, safety, metadata, or command defect that must block publishing |
+
+Validation depth (static-only through scratch-object reproduction) is recorded separately in
+`fidelity_level` (L0 to L3), not in the grade.
 
 Automation status is separate from execution surface:
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,15 @@
 
 This is a public repository for all of Azure Local Troubleshooting guides (TSGs), known issues and reporting feedback - this repo is intended to provide a central location for community driven supportability content. This is the material that is referenced by Customer Support Services when a ticket is created, by Azure Local engineering responding to an incident, and by users when self discovering resolutions to active system issues.
 
+## Table of contents
+
+- [PR review guidelines and checklists](#pr-review-guidelines-and-checklists)
+- [Applicability and automation metadata](#applicability-and-automation-metadata)
+- [Language assistance guidelines](#language-assistance-guidelines)
+- [PowerShell code guidelines](#powershell-code-guidelines)
+- [Link guidelines](#link-guidelines)
+- [New file guidelines](#new-file-guidelines)
+
 ## PR Review Guidelines and Checklists
 ### Review Process Guidance
 - Focus on consistency with existing documentation and templates
@@ -15,7 +24,7 @@ This is a public repository for all of Azure Local Troubleshooting guides (TSGs)
 ### Priority Review Areas
 When reviewing any document, prioritize checking these elements (in order of importance):
 1. Safety issues (potentially harmful code)
-2. Technical inaccuracies 
+2. Technical inaccuracies
 3. Missing critical information
 4. Structural improvements
 5. Style and formatting issues (only if significantly impacting readability)
@@ -33,6 +42,8 @@ Format each review comment with:
   - [ ] PowerShell examples include proper error handling
   - [ ] Version-specific information is clearly indicated
   - [ ] Prerequisites are accurate and complete
+  - [ ] Applicable Azure Local products, deployment modes, and supported versions are explicit
+  - [ ] Claims identify their evidence source and validation status
 
 - **Formatting and Structure**
   - [ ] Follows consistent markdown formatting for commands vs. outputs
@@ -40,25 +51,41 @@ Format each review comment with:
   - [ ] Employs logical headings and subheadings
   - [ ] Contains Table of Contents for documents exceeding 3 sections
   - [ ] Code examples use consistent formatting and indentation
+  - [ ] Customer-facing prose contains no emoji
 
 - **User Experience**
   - [ ] Instructions are complete without assumptions of prior knowledge
   - [ ] Examples include realistic scenarios relevant to Azure Local
   - [ ] Links follow the guidelines (no version references in URLs)
   - [ ] Images are properly placed in an images/ subfolder
+  - [ ] Every action states the expected result and a stop condition for unexpected output
+  - [ ] The `azure-local-supportability/tsg-metadata/v1` marker is present and current
 
 #### Troubleshooting Guide (TSG) Checklist
 - [ ] Clear symptoms description at the beginning
 - [ ] Problem statement defines impact and scope
+- [ ] Every administrator detection surface is shown or explicitly marked not evident
 - [ ] Diagnostic steps are in logical sequence
 - [ ] Resolution steps are distinct from diagnostic steps
+- [ ] State-changing steps carry a [LOW RISK], [MEDIUM RISK], or [HIGH RISK] label
+- [ ] Preconditions, workload impact, rollback, and escalation criteria are explicit
 - [ ] Verification steps confirm issue resolution
 - [ ] PowerShell code follows safety guidelines
+- [ ] Causal claims are framed as evidence-backed contributing factors
+
+Use the administrator-surface states consistently:
+
+- `shown`: the article names the exact signal and where to find it.
+- `not-evident`: an authoritative check with a stated scope, time window, or freshness basis shows
+  that this surface does not carry the issue.
+- `absent`: the author has not characterized the surface. This is a documentation gap and is not
+  publish-ready evidence that the issue does not appear there.
 
 #### How-To Guide Checklist
 - [ ] Clear prerequisites section
 - [ ] Numbered step-by-step instructions
 - [ ] Each step has a single, clear action
+- [ ] Each state-changing step includes risk, impact, expected result, and rollback
 - [ ] Verification steps follow configuration changes
 - [ ] Expected outcomes are clearly documented
 - [ ] Alternative approaches mentioned where applicable
@@ -68,6 +95,60 @@ Format each review comment with:
 - [ ] Tables used for parameter/setting references
 - [ ] Examples provided for complex configurations
 - [ ] Default values clearly indicated
+- [ ] Supported values, constraints, applicability, and validation methods are explicit
+
+## Applicability and automation metadata
+
+Every article template carries one hidden JSON marker with schema
+`azure-local-supportability/tsg-metadata/v1`. Preserve it when creating an article and replace
+its placeholders. The authoritative allowed values are in
+[`tsg-metadata.schema.json`](../TSG/Templates/tsg-metadata.schema.json). The marker records:
+
+- Document type and applicable products
+- Detector type and signal
+- Validation fidelity level
+- Technical grade, or `null` until TSG-FORGE produces one
+- Reproduction substrate
+- Automation status
+- Last validation date and internal specification reference
+
+Do not place customer names, cluster names, subscription IDs, IP addresses, credentials, or other
+environment-specific identifiers in this marker.
+
+Use these fidelity values consistently:
+
+| Level | Evidence required |
+| --- | --- |
+| L0 | Static structure, safety, and persona review only |
+| L1 | Every diagnostic command exercised read-only |
+| L2 | The real detector and remediation direction exercised with a safe proxy |
+| L3 | The real failure and remediation exercised on an isolated scratch object |
+| L4 | Full baseline, inject, detect, mitigate, and revalidate loop exercised live |
+
+Technical grade records the TSG outcome, not the cluster outcome:
+
+| Grade | Meaning |
+| --- | --- |
+| `null` | No TSG-FORGE technical grade has been established |
+| A | The detector, discoverability, documented mitigation, and revalidation passed |
+| B | The live loop passed, but documented discoverability is incomplete |
+| C | Recovery required fallback automation or the failure detail was not actionable |
+| F | The bad state was not detected or the documented mitigation did not restore service |
+
+Automation status is separate from execution surface:
+
+| Status | Meaning |
+| --- | --- |
+| `not-assessed` | No automation assessment has been completed |
+| `scaffold` | Metadata exists, but executable automation is incomplete |
+| `ready` | Automation is implemented and awaiting a qualifying live run |
+| `proven` | Automation completed its declared validation loop |
+| `blocked` | A named safety, access, or substrate requirement prevents the run |
+| `manual` | The verification surface requires an operator |
+
+Execution surface describes where steps run. Use `on-device`, `mixed`, `cloud-diagnostic`,
+`cloud-control`, or `thin`. `manual` is an automation status, not an execution surface. Do not
+store execution-surface values in `validation.automation_status`.
 
 ## Language Assistance Guidelines
 When reviewing or suggesting language improvements (in order of importance):
@@ -81,12 +162,16 @@ Frame language suggestions as "improvements" rather than "corrections"
 When reviewing or suggesting PowerShell code in documentation:
 - Pay special attention to commands that change environment state (e.g., restart, stop, remove, set, write).
 - For state-changing commands:
+  - Assign one canonical risk label: [LOW RISK], [MEDIUM RISK], or [HIGH RISK].
   - Verify code is safe for production environments.
   - Implement defensive coding techniques (check conditions before taking action). But avoid excessive complexity.
-  - Include verification steps before and after changes.
+  - Include a pre-check, expected output, stop condition, rollback, and verification.
   - Ensure commands don't disrupt workloads. If they do, provide clear warnings.
   - Check for proper error handling.
   - Use placeholders like <hostname> instead of hardcoded values.
+- For read-only commands:
+  - Use [READ-ONLY] as the action type, not as a risk label.
+  - Record the risk label as not applicable because the command does not change state.
 
 Example:
 ```powershell
@@ -113,6 +198,6 @@ Get-Service -Name "NonExistentService"
 ## New File Guidelines
 - Most new MD files should follow naming convention: <Type>-<Topic>-<Specifics>.md
 - Most new MD files should use one of the templates provided
-- The table of contents in the component's README.md files should be updated when adding new content
+- The component README.md inventory must be updated with the article type, applicable products,
+  owner, validation grade, automation readiness, and last validation date
 - Place images in an images/ subfolder within the relevant component
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,15 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
+## Table of contents
+
+- [Contribution process](#contribution-process)
+- [Quick start](#quick-start-5-minutes)
+- [Requirements](#requirements)
+- [Detailed guidelines](#detailed-guidelines)
+- [Need help](#need-help)
+- [Additional resources](#additional-resources)
+
 ## Contribution Process
 
 1. **Fork** this repository
@@ -55,10 +64,12 @@ Don't see a component? [See all components](./README.md#table-of-contents)
 
 1. **Copy the template** from Step 1
 2. **Replace placeholders** (marked with `{curly braces}`)
-3. **Test all code examples** - they must be safe for production
-4. **Save with correct naming**: `<Type>-<Topic>-<Specifics>.md`
-5. **Update the component README.md** to list your new file
-6. **Submit a pull request** with your changes
+3. **Declare applicability**: products, deployment modes, versions, and exclusions
+4. **Complete the hidden metadata marker**: detector, fidelity, substrate, and automation status
+5. **Test all code examples**: they must be safe for production
+6. **Save with correct naming**: `<Type>-<Topic>-<Specifics>.md`
+7. **Update the component README.md** with validation and automation fields
+8. **Submit a pull request** with evidence for every tested claim
 
 Reference [Markdown Snippets](./TSG/Templates/Markdown-Snippets.md) for helpful formatting tips, diagrams, and more.
 
@@ -69,9 +80,13 @@ Reference [Markdown Snippets](./TSG/Templates/Markdown-Snippets.md) for helpful 
 All PowerShell/scripts **MUST be safe for production**
 
 - Use placeholders like `<hostname>` instead of real values
-- Include verification steps after changes
+- Label state-changing commands [LOW RISK], [MEDIUM RISK], or [HIGH RISK]
+- Include a pre-check, expected output, stop condition, rollback, and verification
 - Add comments explaining what commands do
 - Test all examples before submitting
+
+For a read-only command, use [READ-ONLY] as the action type and record risk as not applicable.
+Do not label a non-mutating check [LOW RISK], because that blurs observation and state change.
 
 ```powershell
 # Good: Check state before changing
@@ -83,6 +98,73 @@ if ((Get-Service "ServiceName").Status -eq "Stopped") {
 Start-Service "ServiceName"
 ```
 
+### Product applicability
+
+Verify product and version applicability against current public Microsoft documentation. State
+what the article applies to and what it does not apply to. Consider Azure Local connected and
+disconnected deployments, disaggregated deployments, multi-rack deployments, and any feature-specific
+requirements. Do not infer applicability from a similar product or older release.
+
+### TSG automation metadata
+
+Every article created from a template includes one hidden
+`azure-local-supportability/tsg-metadata/v1` JSON marker. Fill it in and keep it valid JSON. The
+authoritative allowed values are in
+[`tsg-metadata.schema.json`](./TSG/Templates/tsg-metadata.schema.json). The marker must identify:
+
+- Document type
+- Applicable products
+- Detector type and signal
+- Validation fidelity level, from L0 through L4
+- Technical grade, or `null` until TSG-FORGE produces one
+- Reproduction substrate
+- Automation status
+- Last validation date and the internal test specification reference, when available
+
+Use `null` for a validation date that has not been established. Never add customer or lab
+identifiers to tracked metadata.
+
+Use the same fidelity scale for every article:
+
+| Level | Evidence required |
+| --- | --- |
+| L0 | Static structure, safety, and persona review only |
+| L1 | Diagnostic commands exercised read-only |
+| L2 | Real detector and remediation direction exercised with a safe proxy |
+| L3 | Real failure and remediation exercised on an isolated scratch object |
+| L4 | Full baseline, inject, detect, mitigate, and revalidate loop exercised live |
+
+Technical grade records the TSG outcome:
+
+| Grade | Meaning |
+| --- | --- |
+| `null` | No TSG-FORGE technical grade has been established |
+| A | Detector, discoverability, documented mitigation, and revalidation passed |
+| B | Live loop passed, but documented discoverability is incomplete |
+| C | Recovery required fallback automation or failure detail was not actionable |
+| F | The bad state was not detected or the documented mitigation did not restore service |
+
+Use `not-assessed`, `scaffold`, `ready`, `proven`, `blocked`, or `manual` for automation status.
+Record `on-device`, `mixed`, `cloud-diagnostic`, `cloud-control`, or `thin` separately as the
+execution surface. `manual` is an automation status, not an execution surface.
+
+### Evidence required in a pull request
+
+Include the following in the pull request description:
+
+1. Static structure and safety result
+2. Commands or procedures exercised, with the environment class and product build
+3. Expected and observed results
+4. Rollback or cleanup result
+5. Remaining automation blockers
+
+Maintainers run the TSG-FORGE persona and live-validation workflow. A static pass alone does not
+prove that a remediation restores a cluster.
+
+For administrator detection surfaces, use `shown`, `not-evident`, or `absent`. A
+`not-evident` claim requires an authoritative check with a stated scope, time window, or freshness
+basis. `absent` means the surface is still uncharacterized and is a publication gap.
+
 ## Detailed Guidelines
 
 <details>
@@ -90,11 +172,11 @@ Start-Service "ServiceName"
 
 | Document Type    | Purpose                                         | Template                                                               | Structure                                              |
 | ---------------- | ----------------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------ |
-| **Troubleshoot** | Help users fix specific errors or problems      | [`Troubleshoot-Template.md`](./TSG/Templates/Troubleshoot-Template.md) | Symptoms → Root Cause → Resolution → Prevention        |
-| **Reference**    | Provide configuration examples and settings     | [`Reference-Template.md`](./TSG/Templates/Reference-Template.md)       | Overview → Configuration → Examples → Validation       |
-| **How-To**       | Step-by-step instructions                       | [`HowTo-Template.md`](./TSG/Templates/HowTo-Template.md)               | Prerequisites → Steps → Verification → Next Steps      |
-| **Deep Dive**    | Technical explanations and architecture details | [`DeepDive-Template.md`](./TSG/Templates/DeepDive-Template.md)         | Overview → Technical Details → Examples → References   |
-| **Overview**     | High-level introductions and summaries          | [`Overview-Template.md`](./TSG/Templates/Overview-Template.md)         | Introduction → Key Concepts → Architecture → Resources |
+| **Troubleshoot** | Help users fix specific errors or problems      | [`Troubleshoot-Template.md`](./TSG/Templates/Troubleshoot-Template.md) | Symptoms > Diagnosis > Contributing factors > Mitigation > Verification |
+| **Reference**    | Provide configuration examples and settings     | [`Reference-Template.md`](./TSG/Templates/Reference-Template.md)       | Overview > Configuration > Examples > Validation       |
+| **How-To**       | Step-by-step instructions                       | [`HowTo-Template.md`](./TSG/Templates/HowTo-Template.md)               | Prerequisites > Steps > Verification > Next steps      |
+| **Deep Dive**    | Technical explanations and architecture details | [`DeepDive-Template.md`](./TSG/Templates/DeepDive-Template.md)         | Overview > Technical details > Examples > References   |
+| **Overview**     | High-level introductions and summaries          | [`Overview-Template.md`](./TSG/Templates/Overview-Template.md)         | Introduction > Key concepts > Architecture > Resources |
 
 </details>
 
@@ -109,8 +191,8 @@ Type-Topic-Specifics.md
 
 **Examples:**
 
-- `Troubleshoot-SDNExpress-HealthAlert-HostNotConnectedToController`
-- `Reference-TOR-Disaggregated-Switched-Storage`
+- `Troubleshoot-SDNExpress-HealthAlert-HostNotConnectedToController.md`
+- `Reference-TOR-Disaggregated-Switched-Storage.md`
 </details>
 
 <details>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,10 +139,13 @@ Technical grade records the TSG outcome:
 | Grade | Meaning |
 | --- | --- |
 | `null` | No TSG-FORGE technical grade has been established |
-| A | Detector, discoverability, documented mitigation, and revalidation passed |
-| B | Live loop passed, but documented discoverability is incomplete |
-| C | Recovery required fallback automation or failure detail was not actionable |
-| F | The bad state was not detected or the documented mitigation did not restore service |
+| A | The article is complete for its type, safety gates are present, metadata is valid, links resolve, and lint is clean |
+| B | Usable, but non-blocking gaps remain, such as missing optional evidence or a documented false-positive warning |
+| C | Incomplete validation, fallback-only validation, missing required routing metadata, or unclear automation readiness |
+| F | A structural, safety, metadata, or command defect that must block publishing |
+
+Validation depth (static-only through scratch-object reproduction) is recorded separately in
+`fidelity_level` (L0 to L3), not in the grade.
 
 Use `not-assessed`, `scaffold`, `ready`, `proven`, `blocked`, or `manual` for automation status.
 Record `on-device`, `mixed`, `cloud-diagnostic`, `cloud-control`, or `thin` separately as the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,8 +144,8 @@ Technical grade records the TSG outcome:
 | C | Incomplete validation, fallback-only validation, missing required routing metadata, or unclear automation readiness |
 | F | A structural, safety, metadata, or command defect that must block publishing |
 
-Validation depth (static-only through scratch-object reproduction) is recorded separately in
-`fidelity_level` (L0 to L3), not in the grade.
+Validation depth (static-only through a full live inject-detect-mitigate loop) is recorded
+separately in `fidelity_level` (L0 to L4), not in the grade.
 
 Use `not-assessed`, `scaffold`, `ready`, `proven`, `blocked`, or `manual` for automation status.
 Record `on-device`, `mixed`, `cloud-diagnostic`, `cloud-control`, or `thin` separately as the

--- a/TSG/Templates/Component/CONTRIBUTING-Template.md
+++ b/TSG/Templates/Component/CONTRIBUTING-Template.md
@@ -1,43 +1,235 @@
 # Contributing to Azure Local {COMPONENT_NAME} Documentation
 
-<!-- Instructions: Replace {COMPONENT_NAME} with the actual component name -->
+<!-- Instructions: Replace {COMPONENT_NAME} with the actual component name and remove every instruction comment before submitting the copied component file. -->
 
-This document extends the [universal contribution guidelines](../Templates/CONTRIBUTING.md) with component-specific requirements.
+This document extends the [repository contribution guide](../../CONTRIBUTING.md) with component-specific requirements for `{COMPONENT_NAME}`.
 
-## Component-Specific Guidelines
+Use this file to define how contributors should scope, validate, and review content for this component. Do not copy article-only sections such as Symptoms, Root Cause, or Resolution into this contribution guide. Instead, require authors to use the correct article template and to complete the checks below.
 
-<!-- Instructions: Replace this section with component-specific guidelines that are unique to this component area. Examples:
-     - Networking: Different topologies (Storage Switched vs Switchless)
-     - Storage: Different storage types (S2D, external storage)
-     - Security: Different security contexts (on-premises vs cloud-connected)
-     - Update: Different update channels and timing considerations
--->
-{COMPONENT_SPECIFIC_GUIDELINES}
+## Table of Contents
+
+- [Fast Path: Copy, Lint, and PR Evidence](#fast-path-copy-lint-and-pr-evidence)
+- [Component Scope and Applicability](#component-scope-and-applicability)
+- [Required Article Metadata](#required-article-metadata)
+- [Safe and Testable Authoring](#safe-and-testable-authoring)
+- [Evidence, Validation, and Discoverability](#evidence-validation-and-discoverability)
+- [File Naming](#file-naming)
+- [Structure](#structure)
+- [Before Opening a Pull Request](#before-opening-a-pull-request)
+- [Need Help](#need-help)
+
+## Fast Path: Copy, Lint, and PR Evidence
+
+Use this path when turning the template into a component `CONTRIBUTING.md` and pull request (PR) evidence:
+
+1. Copy this file to `TSG/{ComponentName}/CONTRIBUTING.md` and customize all component-specific scope, topic, and folder entries.
+2. Remove every instruction comment, `{curly brace}` placeholder, and `replace-me` value before the PR is ready for review.
+3. Confirm the PR summary fields below are ready for a reviewer:
+
+   | Field | PR-ready answer |
+   | --- | --- |
+   | Non-technical impact | What customer or operator problem this content helps with. |
+   | Owner and required sign-off | Component owner, support owner, partner, SI, or OEM reviewer. |
+   | Workload impact or downtime risk | None, possible disruption, maintenance window required, or unknown and blocked. |
+   | Technical grade and validation evidence | `validation.technical_grade`, TSG-FORGE report or spec evidence, lint result, link check, or not applicable with reason. |
+   | Remaining blockers | Open evidence, applicability, support-boundary, or owner questions. |
+
+4. Run source-branch lint from the repository that contains the changed markdown:
+
+   ```bash
+   python3 <path-to-tsg-forge-harness.py> --lint --tsg <path-to-changed-markdown>
+   ```
+
+   `<path-to-tsg-forge-harness.py>` is the path to the TSG-FORGE `harness.py` script in the maintainer's checked-out tooling. Accepted output is `LINT (structure/safety component only) A` for this template, or a documented type false positive with the exact finding ID and reason. If the contributor cannot run TSG-FORGE locally, paste the command attempted, the error output, and a request for the maintainer to run the same lint before merge.
+
+5. Paste this evidence snippet into the PR description:
+
+   ```text
+   Component owner:
+   Customer impact summary:
+   Workload impact or downtime risk:
+   Applicable products and supported versions:
+   validation.technical_grade:
+   TSG-FORGE report or spec evidence:
+   TSG-FORGE lint result:
+   Link check result:
+   Remaining blockers:
+   ```
+
+The `../../CONTRIBUTING.md` link is intentional for the copied file at `TSG/{ComponentName}/CONTRIBUTING.md`. When reviewing this source template, validate that link in the copied component-file context.
+
+## Component Scope and Applicability
+
+<!-- Instructions: Replace this section with component-specific scope rules. Name what belongs here, what does not, and which team or vendor owns handoff cases. -->
+
+Contributions for `{COMPONENT_NAME}` must declare the supported scope before any diagnostic or action steps are accepted:
+
+- **Applicable products**: Azure Local, plus any feature, extension, or component name this guidance applies to.
+- **Supported versions**: Azure Local release, operating system build, solution build, Solution Builder Extension (SBE) version, firmware version, or driver version as applicable. Use `replace-me` until the exact range is known.
+- **Operation phase**: Deployment, add node, update, upgrade, day-2 or post-deployment operations, or break/fix.
+- **Topology and environment**: switchless or switched networking, storage type, Arc-connected state, Azure Kubernetes Service (AKS) Arc, Arc VMs, Original Equipment Manufacturer (OEM) family, or other component-specific topology.
+- **Owner and handoff**: customer IT, partner or system integrator (SI), OEM vendor, Microsoft Customer Support Services (CSS), or product group. State when the issue is outside `{COMPONENT_NAME}`.
+- **Support boundary**: prerequisites, unsupported configurations, or cases that need OEM or Microsoft support before proceeding.
+
+Completed mini-example:
+
+| Scope field | Completed sample |
+| --- | --- |
+| Component | Networking |
+| Applicable products | Azure Local connectivity validation for Arc-connected clusters |
+| Supported versions | Azure Local 23H2 and later, exact build range listed in each article |
+| Operation phase | Deployment readiness and update readiness |
+| Topology and environment | Switched or switchless, proxy mode, DNS forwarder, and outbound firewall path |
+| Owner and handoff | Customer networking team for firewall or proxy, OEM vendor only when adapter firmware or driver support is involved |
+| Support boundary | Stop when public endpoint allowlists, proxy credentials, or TLS inspection policy cannot be verified |
+
+### Component topic areas
+
+<!-- Instructions: List 4 to 6 main topic areas for this component. Use PascalCase without spaces. The Networking sample row is intentionally complete, so copied files have a concrete pattern to follow. -->
+
+| Topic area | Use for | Applicability notes |
+| --- | --- | --- |
+| `OutboundConnectivity` | Firewall, proxy, DNS, and required endpoint access for Azure Local | Include topology, proxy mode, and Azure Local release or build. |
+| `{TOPIC_1}` | {TOPIC_1_DESCRIPTION} | {TOPIC_1_APPLICABILITY} |
+| `{TOPIC_2}` | {TOPIC_2_DESCRIPTION} | {TOPIC_2_APPLICABILITY} |
+| `{TOPIC_3}` | {TOPIC_3_DESCRIPTION} | {TOPIC_3_APPLICABILITY} |
+| `{TOPIC_4}` | {TOPIC_4_DESCRIPTION} | {TOPIC_4_APPLICABILITY} |
+
+Use this handoff matrix for cross-component cases:
+
+| Case | Primary owner or handoff | Article requirement |
+| --- | --- | --- |
+| Firmware, BIOS, driver, or hardware qualification | OEM vendor with Microsoft CSS as needed | Name model, firmware or driver range, and support-boundary evidence. |
+| Solution Builder Extension package, model/SKU match, or solution extension content | OEM vendor or SBE publisher | Name SBE version, hardware family, and validation evidence. |
+| Network symptom with storage, update, or compute impact | Start with the component whose evidence proves the failing layer | Explain why the issue is or is not in this component's lane. |
+| VM workload drain, reboot, or live migration exposure | Customer workload owner and app or VM engineer | State workload impact, downtime risk, maintenance window, and validation plan. |
+| Repeated site deployment variance | Partner or SI deployment owner | Record hardware family, topology, version variance, and reuse guidance for future sites. |
+
+## Required Article Metadata
+
+Component README files should index every article and include its title, document type, link, applicable products, supported versions, Highest action classification, Highest state-changing risk, workload impact or downtime risk, owner or handoff, metadata-marker status, validation fidelity, `validation.technical_grade`, TSG-FORGE report or spec evidence, reproduction substrate, automation status, execution surface, and last validated date.
+
+Each article that is created from an article template must contain one valid HTML-comment JSON marker that starts with the literal `<!-- tsg-metadata` label and follows schema `azure-local-supportability/tsg-metadata/v1`. Do not embed that article metadata marker in this component contribution guide. Instead, require article authors to copy the marker from [Markdown snippets](../Templates/Markdown-Snippets.md), validate it against the copied-file-relative [metadata schema](../Templates/tsg-metadata.schema.json), keep `products` explicit, and set placeholders only while drafting.
+
+For every contributed article, require these metadata fields or their article-template equivalent:
+
+- **Document type**: `troubleshoot`, `how-to`, `reference`, `deep-dive`, or `overview`, matching the canonical schema value for the article template. Do not invent a Known Issue document type unless the repository adds an approved Known Issue template and schema value.
+- **Applicable products**: explicit product and component names. Do not leave this implicit.
+- **Supported versions**: exact version range, build, or `replace-me` during draft only.
+- **Detector**: `command`, `control-plane`, `envchecker`, `eventlog`, `feature`, `manual`, `none`, `portal`, `registry`, `service`, or `telemetry`. When `detector.type` is `none`, set `detector.signal` to JSON `null`; when selecting a detector, set both fields together.
+- **Validation**: fidelity level, technical grade, reproduction substrate, automation status, last validated date, and TSG-FORGE spec reference when available.
+- **Severity**: required for troubleshooting content and any approved component-specific known issue content when the article describes customer impact or a failing check.
+
+Use this metadata vocabulary consistently:
+
+| Field | Values | Meaning |
+| --- | --- | --- |
+| Fidelity level | L0, L1, L2, L3, L4 | L0 means static review only. L1 means read-only diagnostics were run. L2 means a safe proxy or configuration-restore loop proved the signal or fix direction. L3 means an isolated scratch object reproduced the failure mode and fix. L4 means a full live inject, detect, mitigate, and revalidate loop was proven. |
+| Technical grade | JSON `null`, `A`, `B`, `C`, `F` | `validation.technical_grade` is the authoritative TSG-FORGE grade. Set it to JSON `null` until a TSG-FORGE report or spec evidence assigns A, B, C, or F. Do not invent a separate grade vocabulary in component README files. |
+| Automation status | `not-assessed`, `scaffold`, `ready`, `proven`, `blocked`, `manual` | Maturity of validation automation. This is not the same as execution surface. |
+| Execution surface | `on-device`, `mixed`, `cloud-diagnostic`, `cloud-control`, `thin` | Where the diagnostic or action runs. Do not write these values into `automation_status`. |
+| Reproduction substrate | `vm`, `hardware`, `either`, `none` | Where validation can be reproduced. Use `none` for explanation-only content. |
+| Last validated | ISO date or `null` in draft metadata | Date of the latest cited validation evidence. |
+
+## Safe and Testable Authoring
+
+All contributed commands, scripts, portal actions, and configuration changes must be production-safe, tested, and labeled with a canonical action classification:
+
+- [READ-ONLY]: diagnostics, status checks, link checks, or metadata checks that do not change state. Risk is not applicable because no state changes.
+- [LOW RISK]: state-changing actions with narrow, reversible impact and no expected workload or availability effect.
+- [MEDIUM RISK]: reversible configuration changes, service restarts, cache cleanup, firewall updates, or changes that may briefly affect manageability.
+- [HIGH RISK]: node reboot, drain, firmware change, BitLocker or Secure Boot change, storage repair, cluster quorum change, destructive cleanup, or any step that can affect workload availability.
+
+Every action pattern in a contributed article must include these fields:
+
+| Field | Requirement |
+| --- | --- |
+| Action classification | [READ-ONLY] when no state changes. Use [LOW RISK], [MEDIUM RISK], or [HIGH RISK] only when the action may change state. |
+| Risk statement | For [READ-ONLY], state that risk is not applicable because no state changes. For state-changing actions, explain why the selected risk label is correct. |
+| Required privilege | Role, local admin right, Azure role, OEM access, or support entitlement needed before the action. |
+| Workload or maintenance gate | Whether the action needs a maintenance window, workload owner approval, node drain, reboot plan, or no workload impact. |
+| Pre-check | What the operator must confirm before running the action, including prerequisites, current state, backup, recovery key, maintenance window, and workload impact. |
+| Action | The exact command or portal action, with placeholders such as `<cluster-name>` and no real customer identifiers. |
+| Expected result or output | The success shape, status, log entry, portal state, or command output the reader should see. |
+| Stop condition | The condition that means the reader must stop and escalate instead of continuing. |
+| Escalation target | Component owner, Microsoft CSS, OEM vendor, product group, or customer workload owner to contact when a stop condition is hit. |
+| Rollback | How to undo the change or return to the previous state. If rollback is not available, label the action [HIGH RISK] and say so before the action. |
+| Expected rollback output | The command output, portal state, or log entry that shows rollback started and completed. |
+| Rollback verification | The independent check that proves the rollback restored the previous state. |
+| Verification | The command, portal check, log, event, or validation run that proves the change worked. |
+
+State-changing PowerShell must check current state before changing it, avoid `-Force` unless justified, set error handling where appropriate, and include verification after changes. Do not include commands that delete drive roots, erase customer data, disable security controls, or reboot or drain nodes without explicit pre-checks, stop conditions, rollback guidance, and a [HIGH RISK] label.
+
+## Evidence, Validation, and Discoverability
+
+Each article must show enough evidence for a reviewer and a field engineer to trust the guidance:
+
+- Include the exact validation performed: lab run, customer-safe repro, command output shape, screenshots, logs, Event IDs, telemetry, or source links.
+- For troubleshooting content, add a **Where this failure appears** section or equivalent that explains the visible symptom and where to collect proof.
+- For remediation content, add a **Verify the fix** step that reruns the relevant health check, command, portal check, or validation procedure.
+- For generated code or action patterns, include expected result/output, stop condition, rollback, and verification as separate prompts.
+- Define acronyms on first use, avoid internal jargon, and write for a public reader who may not know Azure Local team names or support aliases.
+- Cite only public Microsoft documentation for external links. Use Microsoft Learn links without release-specific query strings.
+- Keep internal links relative and verify they resolve after the file is copied into the component folder.
+- Do not include customer names, tenant IDs, subscription IDs, cluster names, IP addresses, secrets, or private support URLs in public articles.
+
+When the article describes how an issue is detected, characterize the administrator-visible surfaces that apply. Use only these states: `shown` when the article provides concrete evidence for the surface, `not-evident` when the surface was checked and does not show the issue, and `absent` when the surface is still uncharacterized. An `absent` surface is not publish-ready.
+
+| Surface | What the article should say |
+| --- | --- |
+| PowerShell on an Azure Local node | Show the `Get-*`, `Test-*`, or `Invoke-*` command and the failing output, or state that node PowerShell does not show the issue. |
+| Azure portal | Name the Azure Local, Arc, Resource Health, or Updates blade if it shows the issue, or state that the Azure portal does not show it. |
+| Windows event logs | Name the log, provider, and Event ID if present, or state that Windows event logs do not show it. |
+| Cluster logs with `Get-ClusterLog` | Show the cluster log signal, or state that `Get-ClusterLog` does not show it. |
+| Windows Failover Cluster Manager | State whether the issue appears as a failed role, resource, or node in Failover Cluster Manager. |
+| Windows Admin Center on a standalone host | State whether Windows Admin Center on a standalone host shows the issue. |
+| Windows Admin Center in the Azure portal | State whether Windows Admin Center in the Azure portal shows the issue. |
+| Component or tool log files on disk | Point to the component log or report file, or state that no component log file is written. |
 
 ## File Naming
 
-Follow the universal naming convention: `<Type>-<Topic>-<Specifics>.md`
+Follow the universal naming convention: `<Type>-<Topic>-<Specifics>.md`.
 
-For this component (`{COMPONENT_NAME}`), use these specific topic areas, or create new ones as needed:
+For this component (`{COMPONENT_NAME}`), use the topic areas above or create a new topic when the component owner approves it.
 
-### `<topics>`:
-<!-- Instructions: List 4-6 main topic areas for this component. Use PascalCase without spaces. Examples:
-     - Networking: ArcGateway, OutboundConnectivity, SDNExpress, TOR
-     - Storage: S2D, ExternalStorage, Performance, Replication
-     - Security: Authentication, Authorization, Certificates, Compliance
--->
-- `{TOPIC_1}` - {TOPIC_1_DESCRIPTION}
-- `{TOPIC_2}` - {TOPIC_2_DESCRIPTION}
-- `{TOPIC_3}` - {TOPIC_3_DESCRIPTION}
-- `{TOPIC_4}` - {TOPIC_4_DESCRIPTION}
+File names must be descriptive, must avoid spaces, and must match the selected document type. Examples:
+
+- `Troubleshoot-OutboundConnectivity-ProxyAuthentication.md`
+- `HowTo-OutboundConnectivity-ConfigureProxy.md`
+- `Reference-OutboundConnectivity-RequiredEndpoints.md`
 
 ## Structure
 
-The repo is organized by major topic areas, you can add new files to existing folders or create new ones as needed. Here's a quick overview of the main folders:
+The repo is organized by major topic areas. Add new files to existing folders when possible, or create new folders when the component owner approves the new topic.
 
-<!-- Instructions: Create a table describing the main folders/topic areas for this component -->
-| Folder                    | Description                                                          |
-|---------------------------|----------------------------------------------------------------------|
-| `{FOLDER_1}/`            | {FOLDER_1_DESCRIPTION}                                               |
-| `{FOLDER_2}/`            | {FOLDER_2_DESCRIPTION}                                               |
-| `{FOLDER_3}/`            | {FOLDER_3_DESCRIPTION}                                               |
+<!-- Instructions: Create a table describing the main folders or topic areas for this component. The first row is a completed example. -->
+
+| Folder | Description | Required README entry |
+| --- | --- | --- |
+| `OutboundConnectivity/` | Proxy, DNS, firewall, and endpoint requirements for Azure Local connectivity. | Title, document type, link, applicable products, supported versions, Highest action classification, Highest state-changing risk, workload impact, owner, metadata-marker status, validation fidelity, `validation.technical_grade`, TSG-FORGE report or spec evidence, reproduction substrate, automation status, execution surface, last validated date. |
+| `{FOLDER_1}/` | {FOLDER_1_DESCRIPTION} | {FOLDER_1_README_ENTRY_REQUIREMENT} |
+| `{FOLDER_2}/` | {FOLDER_2_DESCRIPTION} | {FOLDER_2_README_ENTRY_REQUIREMENT} |
+| `{FOLDER_3}/` | {FOLDER_3_DESCRIPTION} | {FOLDER_3_README_ENTRY_REQUIREMENT} |
+
+Place images in an `images/` subfolder under the relevant topic area. Use descriptive filenames and include alt text in the article.
+
+## Before Opening a Pull Request
+
+A component contribution is not ready for review until every item below is true:
+
+- The copied component `CONTRIBUTING.md` links to the repository contribution guide as `../../CONTRIBUTING.md`.
+- The final file contains no `{curly brace}` placeholders and no authoring instruction comments.
+- The component README indexes every new or changed article with title, document type, link, applicable products, supported versions, Highest action classification, Highest state-changing risk, workload impact, owner, metadata-marker status, validation fidelity, `validation.technical_grade`, TSG-FORGE report or spec evidence, reproduction substrate, automation status, execution surface, and last validated date.
+- Every article uses the correct template and includes the required metadata marker from `../Templates/Markdown-Snippets.md` when it is an article template output.
+- Every applicable product, supported version, operation phase, topology, owner, and support boundary is explicit.
+- Every action uses [READ-ONLY] when no state changes or [LOW RISK], [MEDIUM RISK], or [HIGH RISK] when state may change, and includes pre-check, action, expected result/output, stop condition, rollback, and verification.
+- Evidence is attached or cited in the PR: tested commands, expected outputs, logs, screenshots, Event IDs, telemetry samples, or source links as appropriate.
+- Internal relative links resolve from the copied file location, and external links use public Microsoft documentation without release-specific query parameters.
+- Public content contains no customer identifiers, secrets, tenant IDs, subscription IDs, private IP addresses, private support links, or internal-only URLs.
+- Source-branch TSG-FORGE lint or review has been run on changed markdown. Fix real findings, record any type false positives with the reason, and include the result in the PR description.
+
+## Need Help
+
+- Use the repository contribution guide at [../../CONTRIBUTING.md](../../CONTRIBUTING.md) for universal process, CLA, document-type, and code-safety rules.
+- Use Microsoft Learn for public Azure Local product references: <https://learn.microsoft.com/azure/azure-local/>.
+- Ask the component owner when applicability, version support, risk, or support boundary is unclear.

--- a/TSG/Templates/Component/README-Template.md
+++ b/TSG/Templates/Component/README-Template.md
@@ -1,33 +1,127 @@
-# TSG and Reference Documents for Azure Local {COMPONENT_NAME}
+# Azure Local {COMPONENT_NAME} supportability index
 
 <!-- Instructions: Replace {COMPONENT_NAME} with the actual component name (e.g., "Networking", "Storage", "Security") -->
 
 <!-- Optional: Add cross-reference to related components if applicable -->
-<!-- For {RELATED_COMPONENT} Resources, see [TSG/{RELATED_COMPONENT}/README.md](../{RELATED_COMPONENT}/README.md). -->
+<!-- For {RELATED_COMPONENT} resources, see [TSG/{RELATED_COMPONENT}/README.md](../{RELATED_COMPONENT}/README.md). If an article spans components, list it in the primary owner component and add pointer rows from related components instead of duplicating ownership. -->
 
-## 📚 Table of Contents
+## Directory inventory
 
-<!-- Instructions: Organize content by major topic areas within the component. Each topic should have its own section with relevant documents listed. -->
+<!-- Instructions: Organize content by major topic areas within the component. Each topic should have its own section with a complete inventory table. Do not add troubleshooting-only fields such as symptoms, failure surfaces, or fix verification steps to this index. Put those details in the linked article. -->
+
+Use one row per support article. Every linked article must carry a valid HTML-comment metadata marker using schema `azure-local-supportability/tsg-metadata/v1`; this component index records that the marker exists and summarizes its routing fields, but does not embed article metadata itself. After copying this file to `TSG/{Component}/README.md`, use the schema at [`../Templates/tsg-metadata.schema.json`](../Templates/tsg-metadata.schema.json).
+
+### Inventory legend
+
+| Field | Required value |
+| --- | --- |
+| Article type | Record the article metadata `document_type`: `troubleshoot`, `reference`, `how-to`, `deep-dive`, or `overview`. To add another document type, extend `../Templates/tsg-metadata.schema.json` and add matching article-template guidance before using it in the index. |
+| Title | Use the human-readable article title. |
+| Link | Use a relative link to the article file. |
+| Applicable products | Name the Azure Local product or feature family explicitly, for example `Azure Local 23H2 solution update`, `Arc VM management`, or `Storage Spaces Direct`. Do not use `all` unless the article truly applies to every Azure Local product path. |
+| Supported versions | Name the supported release, build range, or `replace-me` until validated. |
+| Owner | Name the accountable team, component owner, or alias. |
+| Highest action classification | Use `[READ-ONLY]` when every action is non-mutating, `state-changing` when any action can change state, or `None, index-only` when the article has no actions. |
+| Highest state-changing risk | Use the highest state-changing action risk label from the linked article: `[LOW RISK]`, `[MEDIUM RISK]`, or `[HIGH RISK]`. Use `Not applicable` for read-only-only or index-only articles. |
+| Workload or maintenance impact | State whether the linked article can affect workloads, require a maintenance window, require elevated privileges, or is `None known`. |
+| Metadata marker | Use `present` only after confirming the linked article contains the required metadata marker and validates against `../Templates/tsg-metadata.schema.json`. Otherwise use `missing` and fix the article before publishing. When `detector.type` is `none`, `detector.signal` must be JSON `null`; set both detector fields together when selecting another detector type. |
+| Technical grade | Record the article metadata `validation.technical_grade`. Use `null` until TSG-FORGE produces `A`, `B`, `C`, or `F`; do not invent a grade from the README alone. |
+| Validation evidence | Record the evidence pointer machine tooling or reviewers should read, for example the article metadata `validation.spec_ref`, a TSG-FORGE report name, or `None yet`. |
+| Fidelity level | Record the article metadata `validation.fidelity_level`: `L0`, `L1`, `L2`, `L3`, or `L4`. |
+| Reproduction substrate | Record the article metadata `validation.reproduction_substrate`: `vm`, `hardware`, `either`, or `none`. |
+| Automation readiness | Record the article metadata `validation.automation_status`: `not-assessed`, `scaffold`, `ready`, `proven`, `blocked`, or `manual`. Use `manual` for intentionally human-run guidance and `blocked` only when automation is blocked by an unresolved dependency. |
+| Execution surface | Keep this distinct from automation readiness. Use `on-device`, `mixed`, `cloud-diagnostic`, `cloud-control`, or `thin`. |
+| Last validated | Use an ISO date such as `2026-08-17`, or `Not validated`. |
+
+For linked articles that include state-changing actions, confirm the article uses the canonical risk labels `[LOW RISK]`, `[MEDIUM RISK]`, or `[HIGH RISK]` and includes pre-check, action, expected result or output, stop condition, rollback, and verification steps.
+
+### Technical grade and automation rubric
+
+If older review text says validation grade, read it as the article metadata field `validation.technical_grade`. Do not create a separate grade value in this index.
+
+| Value | Meaning |
+| --- | --- |
+| `A` | TSG-FORGE evidence shows the article is complete for its type, safety gates are present, metadata is valid, links resolve, and lint is clean. |
+| `B` | Usable, but non-blocking gaps remain, such as missing optional evidence or a documented false-positive warning. |
+| `C` | Incomplete validation, fallback-only validation, missing required routing metadata, or unclear automation readiness. |
+| `F` | Structural, safety, metadata, or command defect that must block publishing. |
+| `null` | `validation.technical_grade` stays JSON `null` until TSG-FORGE produces `A`, `B`, `C`, or `F`. |
+| `L0` | Static-only validation, such as metadata, lint, link, and persona review. |
+| `L1` | Read-only diagnostic commands or evidence collection were validated. |
+| `L2` | A reversible proxy, mocked input, or faithful data-source validation was used. |
+| `L3` | A scratch object or isolated test object reproduced the failure and recovery path. |
+| `L4` | Full live inject, detect, mitigate, and revalidate loop was proven on a lab substrate. |
+| `not-assessed` | Automation readiness has not been reviewed. |
+| `scaffold` | Automation metadata exists, but runnable automation is not built. |
+| `ready` | Automation is designed and ready for validation, but not yet proven. |
+| `proven` | Automation was validated with evidence. |
+| `blocked` | Automation cannot proceed until a named dependency is resolved. |
+| `manual` | The article intentionally requires a human action or judgment. |
+| `vm`, `hardware`, `either`, `none` | Reproduction substrate values from the metadata schema. |
+| `on-device` | Executable steps run on an Azure Local node. |
+| `mixed` | Steps span on-device and cloud or control-plane surfaces. |
+| `cloud-diagnostic` | Diagnostic evidence comes from cloud telemetry or service data. |
+| `cloud-control` | Actions or checks run through Azure control-plane, portal, or ARM surfaces. |
+| `thin` | No executable diagnostic or remediation surface is present. |
 
 ### {TOPIC_AREA_1}
 <!-- Instructions: Replace {TOPIC_AREA_1} with a descriptive topic area name (e.g., "Arc Gateway & Outbound Connectivity") -->
-- [{DOC_TYPE}: {DOC_TITLE}]({FOLDER_NAME}/{FILE_NAME}.md)
+| Article type | Title | Link | Applicable products | Supported versions | Owner | Highest action classification | Highest state-changing risk | Workload or maintenance impact | Metadata marker | Technical grade | Validation evidence | Fidelity level | Reproduction substrate | Automation readiness | Execution surface | Last validated |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| {DOC_TYPE} | {DOC_TITLE} | [{FILE_NAME}.md]({FOLDER_NAME}/{FILE_NAME}.md) | {APPLICABLE_PRODUCTS} | {SUPPORTED_VERSIONS} | {OWNER} | {[READ-ONLY], state-changing, or None, index-only} | {[LOW RISK], [MEDIUM RISK], [HIGH RISK], or Not applicable} | {WORKLOAD_OR_MAINTENANCE_IMPACT} | {present or missing} | {A, B, C, F, or null} | {SPEC_REF, report name, PR evidence, or None yet} | {L0, L1, L2, L3, or L4} | {vm, hardware, either, or none} | {not-assessed, scaffold, ready, proven, blocked, or manual} | {on-device, mixed, cloud-diagnostic, cloud-control, or thin} | {YYYY-MM-DD or Not validated} |
 <!-- Instructions: 
-     - Replace {DOC_TYPE} with document type (Deep Dive, Troubleshoot, How To, Reference, Overview)
+     - Replace {DOC_TYPE} with the schema document_type token: troubleshoot, reference, how-to, deep-dive, or overview
      - Replace {DOC_TITLE} with descriptive title
      - Replace {FOLDER_NAME} with subfolder name
      - Replace {FILE_NAME} with actual filename following naming convention
-     Repeat this pattern for each document in the topic area -->
+     - Replace {APPLICABLE_PRODUCTS} with explicit Azure Local product or feature scope
+     - Replace {SUPPORTED_VERSIONS} with the supported release or build range
+     - Replace {OWNER} with the accountable team, component owner, or alias
+     - Replace {[READ-ONLY], state-changing, or None, index-only} with the linked-article action classification
+     - Replace {[LOW RISK], [MEDIUM RISK], [HIGH RISK], or Not applicable} with the highest linked-article state-changing risk
+     - Replace {WORKLOAD_OR_MAINTENANCE_IMPACT} with workload, privilege, maintenance-window, or downtime impact
+     - Replace {present or missing} after checking the article metadata marker
+     - Replace {SPEC_REF, report name, PR evidence, or None yet} with the validation evidence source
+     - Replace {L0, L1, L2, L3, or L4} with the metadata fidelity level
+     - Replace {vm, hardware, either, or none} with the metadata reproduction substrate
+     - Replace {YYYY-MM-DD or Not validated} with the latest validation date or Not validated
+     Repeat this row pattern for each document in the topic area -->
 
 ### {TOPIC_AREA_2}
-- [{DOC_TYPE}: {DOC_TITLE}]({FOLDER_NAME}/{FILE_NAME}.md)
+| Article type | Title | Link | Applicable products | Supported versions | Owner | Highest action classification | Highest state-changing risk | Workload or maintenance impact | Metadata marker | Technical grade | Validation evidence | Fidelity level | Reproduction substrate | Automation readiness | Execution surface | Last validated |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| {DOC_TYPE} | {DOC_TITLE} | [{FILE_NAME}.md]({FOLDER_NAME}/{FILE_NAME}.md) | {APPLICABLE_PRODUCTS} | {SUPPORTED_VERSIONS} | {OWNER} | {[READ-ONLY], state-changing, or None, index-only} | {[LOW RISK], [MEDIUM RISK], [HIGH RISK], or Not applicable} | {WORKLOAD_OR_MAINTENANCE_IMPACT} | {present or missing} | {A, B, C, F, or null} | {SPEC_REF, report name, PR evidence, or None yet} | {L0, L1, L2, L3, or L4} | {vm, hardware, either, or none} | {not-assessed, scaffold, ready, proven, blocked, or manual} | {on-device, mixed, cloud-diagnostic, cloud-control, or thin} | {YYYY-MM-DD or Not validated} |
 <!-- Add more documents as needed -->
 
 <!-- Instructions: Add more topic areas as needed. Typical components have 3-5 major topic areas. -->
+
+## Maintenance checklist
+
+- Update this index whenever an article is added, moved, renamed, re-owned, re-validated, or converted for automation.
+- Keep applicable products and supported versions explicit in every row.
+- Keep the owner field current so support, partner, OEM, and engineering readers know where to route follow-up.
+- Keep action classification, state-changing risk, workload or maintenance impact, technical grade, validation evidence, fidelity level, reproduction substrate, automation readiness, execution surface, and last validated aligned with the linked article metadata and latest validation evidence.
+- Use only public Microsoft links for external references in public article rows.
+
+## Before submitting this copied README
+
+Use this gate after copying the template to `TSG/{Component}/README.md`.
+
+| Check | Pass condition |
+| --- | --- |
+| Placeholders and instructions | No `{PLACEHOLDER}` values or `<!-- Instructions:` comments remain. |
+| Copied-context links | `[CONTRIBUTING.md](CONTRIBUTING.md)` resolves to the component contribution guide, and `[repository CONTRIBUTING.md](../../CONTRIBUTING.md)` resolves to the repository contribution guide. |
+| Inventory columns | Every topic table keeps Article type, Title, Link, Applicable products, Supported versions, Owner, Highest action classification, Highest state-changing risk, Workload or maintenance impact, Metadata marker, Technical grade, Validation evidence, Fidelity level, Reproduction substrate, Automation readiness, Execution surface, and Last validated. |
+| Required row values | Every row has a schema-valid document type plus explicit applicable products, supported versions, accountable owner, highest action classification, highest state-changing risk or `Not applicable`, workload or maintenance impact, technical grade from `validation.technical_grade`, validation evidence, fidelity level, reproduction substrate, non-placeholder automation readiness, execution surface, and last validated value. |
+| Metadata marker | Every linked article has the required `azure-local-supportability/tsg-metadata/v1` marker, validates against `../Templates/tsg-metadata.schema.json`, and uses `detector.signal: null` when `detector.type` is `none` before its row is marked `present`. |
+| State-changing articles | Any linked article with state-changing actions keeps risk labels, privilege requirements, workload-impact or maintenance-window gates, pre-check, action, expected result or output, stop condition, rollback, expected rollback output, rollback verification, escalation, and final verification in the linked article. |
+| Row order | Rows are sorted or grouped consistently within each topic area so repeated site work stays predictable. |
+| Public-link hygiene | External references in article rows use public Microsoft links only. |
+| Evidence | The pull request notes what was checked, including placeholder removal, copied-context link validation, metadata-marker confirmation, and latest lint result. |
 
 ---
 
 ## Contributing
 
 For component contribution guidelines see [CONTRIBUTING.md](CONTRIBUTING.md).
-For universal contribution guidelines see [Templates/CONTRIBUTING.md](../Templates/CONTRIBUTING.md)
+For universal contribution guidelines see [repository CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/TSG/Templates/DeepDive-Template.md
+++ b/TSG/Templates/DeepDive-Template.md
@@ -1,45 +1,304 @@
+<!-- tsg-metadata
+{
+  "schema": "azure-local-supportability/tsg-metadata/v1",
+  "document_type": "deep-dive",
+  "products": [
+    "replace-me"
+  ],
+  "detector": {
+    "type": "none",
+    "signal": null
+  },
+  "validation": {
+    "fidelity_level": "L0",
+    "technical_grade": null,
+    "reproduction_substrate": "none",
+    "automation_status": "not-assessed",
+    "last_validated": null,
+    "spec_ref": ""
+  }
+}
+-->
+
 <!--
-DeepDive Template
-- Focus on providing comprehensive understanding of the topic
-- Replace all {placeholders} with relevant content
-- This template provides a suggested structure - adapt it to make sense for your specific content
-    - The goal is clarity and usability for the reader
+Deep Dive Template
 
-Styling
-- Images should be placed in the `./images` folder and referenced
-- Any code block or JSON should be wrapped in triple backticks (```) with language identifier
-- References to Azure Local public documentation should always direct to the latest version
+Use this template for in-depth Azure Local technical explanations, architecture details,
+mechanism walkthroughs, and design context. If the article is primarily about detecting
+and resolving a specific failure, use the troubleshooting template instead.
 
-You can use this regex to find placeholders that need to be replaced (search by Regex in your editor): \{([^}]+)\}
+Authoring rules:
+- Replace every placeholder in braces before publishing.
+- Use no emojis.
+- Do not use em dashes or spaced double hyphens as clause separators in prose.
+- Use public Microsoft Learn or Microsoft documentation links only.
+- Put images in an images folder next to the article.
+- Fence every command, code block, JSON block, or output sample with a language identifier.
 -->
 
 # {Title}
 
 <table border="1" cellpadding="6" cellspacing="0" style="border-collapse:collapse; margin-bottom:1em;">
   <tr>
-    <th style="text-align:left; width: 180px;">Component</th>
-    <td><strong>{Component Name}</strong></td>
+    <th style="text-align:left; width: 220px;">Document type</th>
+    <td><strong>Deep Dive</strong></td>
   </tr>
   <tr>
-    <th style="text-align:left; width: 180px;">Topic</th>
-    <td><strong>{Topic Name}</strong>: {Brief description of the topic}</td>
+    <th style="text-align:left; width: 220px;">Purpose</th>
+    <td>{State what the reader will understand or decide after reading this article.}</td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 220px;">Applicable products</th>
+    <td>{List the Azure Local products, features, components, or OEM platforms this article applies to.}</td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 220px;">Supported versions</th>
+    <td>{List supported Azure Local releases, OS builds, extension versions, firmware versions, or state "not version-specific" with why.}</td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 220px;">Component</th>
+    <td>{Component name}</td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 220px;">Topic</th>
+    <td>{Topic name and brief description.}</td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 220px;">Audience</th>
+    <td>{Primary readers, such as customer admin, Microsoft Customer Support Services (CSS) engineer, partner deployment engineer, original equipment manufacturer (OEM) engineer, or architect.}</td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 220px;">Severity or risk posture</th>
+    <td>{Use "informational" for explanation-only content. If any action changes state, label each action with [LOW RISK], [MEDIUM RISK], or [HIGH RISK].}</td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 220px;">Last reviewed</th>
+    <td>{YYYY-MM-DD}</td>
   </tr>
 </table>
 
 ## Overview
 
-{Brief description of what is covered in this document}
+{Summarize the topic in 3 to 5 sentences. Explain why the topic matters, what problem or decision it helps with, and what the reader should be able to do after reading.}
 
-## Table of Contents
+## Reader routing and publish gate
 
-{Update Table of Contents as needed}
+Use this section as the one-screen summary for leaders, field engineers, workload owners, and specialists who need to decide what to do next before reading the deep details.
 
-- {Deep Dive Area 1}
+### Publish-before-use checklist
 
-## {Deep Dive Topic}
+Do not publish or run copied actions from this template until every item is complete.
 
-{Deep Dive templates should give the reader a better understanding of the topic. This template is very flexible.}
+| Gate | Required before publishing |
+| --- | --- |
+| Placeholders removed | Search for brace placeholders such as `{Title}` and replace every one with article-specific content. Do not publish while any placeholder remains. |
+| Products and versions explicit | Fill in applicable products and supported versions. Include at least one explicit out-of-scope version, topology, or product case. |
+| Public-link hygiene | Use public Microsoft Learn or Microsoft documentation links only. |
+| Metadata marker valid | Keep exactly one `azure-local-supportability/tsg-metadata/v1` marker and update it if the article gains a detector or validation evidence. |
+| Metadata schema checked | Validate the marker against the public schema. The schema lives at [`tsg-metadata.schema.json`](tsg-metadata.schema.json) in the template folder. After copying this article, use the copied file's relative path back to the schema: component root uses `../Templates/tsg-metadata.schema.json`, one nested topic folder uses `../../Templates/tsg-metadata.schema.json`, and each additional nested folder adds one `../`. |
+| Safety contract complete | Every action has an action type, required privilege, workload or maintenance gate, pre-check, action, expected result or output, stop condition, rollback with expected output, rollback verification, final verification, and escalation target. State-changing actions also have a [LOW RISK], [MEDIUM RISK], or [HIGH RISK] label. |
+| Evidence sanitized | Remove customer identifiers, secrets, private tenant values, internal URLs, and lab-only names from examples and artifacts. |
 
-### {Sub Topic 1}
+### Choose the right template
 
----
+| Reader need | Use this template? | Use instead |
+| --- | --- | --- |
+| Explain how an Azure Local mechanism works, what evidence proves it, and where the boundaries are. | Yes. Use Deep Dive. | Not applicable. |
+| Detect and resolve a specific failure or validator result. | No. | Troubleshoot template. |
+| Perform a task through ordered steps. | No, unless the steps are only examples inside a broader explanation. | How-To template. |
+| List settings, limits, defaults, or parameters. | No, unless the reference data supports a mechanism explanation. | Reference template. |
+| Introduce a broad component or feature at a high level. | No. | Overview template. |
+
+### One-screen decision summary
+
+| Decision field | Author prompt |
+| --- | --- |
+| Customer capability gained | {State what the customer can understand, decide, prevent, or operate after reading.} |
+| Business or workload impact | {State whether the topic can affect virtual machine (VM) availability, storage, networking, updates, security posture, deployment, or customer operations.} |
+| Workload owner view | {State whether workload owners should expect downtime, live migration, restart, drain, degraded performance, or no workload impact.} |
+| Downtime and maintenance window | {State expected downtime, maintenance-window need, rough duration, and the reason. Use "none expected" only when evidence supports it.} |
+| Primary owner | {Name the likely owner, such as customer IT, Microsoft Customer Support Services (CSS), partner or system integrator (SI), Microsoft engineering, original equipment manufacturer (OEM) vendor, or network team.} |
+| Handoff lane | {State how a reader proves this is their lane or not their lane, then name the next owner and the evidence to hand off.} |
+| Fastest safe next action | {Give the first read-only check or decision that unblocks the customer fastest.} |
+| Stop and escalate when | {List the first condition that should stop self-service and trigger Microsoft Support, partner, OEM, or product-group escalation.} |
+| Multi-node or multi-site repeatability | {State whether the guidance applies per node, per cluster, per site, or per fleet, plus batching guidance and the validation loop to repeat after each batch.} |
+
+## Scope and non-goals
+
+| Area | Guidance |
+| --- | --- |
+| In scope | {List the concepts, scenarios, signals, and products covered.} |
+| Out of scope | {List adjacent areas this article does not cover and point to public Microsoft documentation when available.} |
+| Applies when | {Describe the product state, deployment phase, topology, or configuration where this explanation is valid.} |
+| Does not apply when | {Describe clear exclusions so readers do not apply the guidance to the wrong product, version, or topology.} |
+
+## Prerequisites and assumptions
+
+| Prerequisite | Required value or condition | How to check |
+| --- | --- | --- |
+| Product and supported versions | {Example: Azure Local {release or later}.} | {How the reader confirms the product and version.} |
+| Example, product and version | Azure Local 23H2 or later, if applicable to the topic. | In Azure portal, open the Azure Local cluster Overview page and record the reported version. |
+| Permissions | {Required role or local privilege.} | {How to verify access before continuing.} |
+| Tools | {Required tools, portals, PowerShell modules, or logs.} | {How to confirm the tool is present and current.} |
+| Cluster or workload state | {Required health, maintenance, workload, or connectivity state.} | {Read-only pre-check.} |
+| Required artifacts | {Logs, screenshots, configuration exports, or evidence needed.} | {Where to collect them.} |
+
+## Table of contents
+
+- [Overview](#overview)
+- [Reader routing and publish gate](#reader-routing-and-publish-gate)
+- [Scope and non-goals](#scope-and-non-goals)
+- [Prerequisites and assumptions](#prerequisites-and-assumptions)
+- [Architecture and technical details](#architecture-and-technical-details)
+- [Evidence and observability](#evidence-and-observability)
+- [Case-ready evidence and source authority](#case-ready-evidence-and-source-authority)
+- [Operational boundaries and safety](#operational-boundaries-and-safety)
+- [Action pattern, if this article includes steps](#action-pattern-if-this-article-includes-steps)
+- [Validation](#validation)
+- [Future test automation metadata](#future-test-automation-metadata)
+- [References](#references)
+
+## Architecture and technical details
+
+{Explain the mechanism, architecture, data flow, trust boundary, control plane, data plane, dependencies, and important failure modes. Keep this section explanatory. Move step-by-step remediation to the action pattern section when applicable.}
+
+### Key concepts and definitions
+
+| Term | Definition | Why it matters |
+| --- | --- | --- |
+| {Term} | {Definition in plain language.} | {How this affects the reader's decision or operation.} |
+
+### Dependency map
+
+| Dependency | Direction | Required state | Timeout or degraded behavior | Failure mode | Evidence source |
+| --- | --- | --- | --- | --- | --- |
+| {Dependency name} | {Inbound, outbound, local, cluster, Azure control plane, or OEM.} | {Expected healthy state.} | {Expected timeout, retry, stale-data, or degraded-state behavior.} | {How this dependency fails and what component sees the failure first.} | {Log, cmdlet, portal surface, or public documentation source.} |
+
+## Evidence and observability
+
+Use this section to explain where the concept can be observed. Use admin surface states exactly as `shown`, `not-evident`, or `absent`: `shown` means the surface carries useful evidence, `not-evident` means the surface was checked and is not expected to show this topic, and `absent` means the author has not characterized the surface yet. Articles with `absent` surfaces are not publish-ready.
+
+| Surface | State | What to look for | Expected healthy signal | Abnormal or important signal | Limitations |
+| --- | --- | --- | --- | --- | --- |
+| PowerShell on an Azure Local node | {shown, not-evident, or absent} | {Get-* or Invoke-* command, if applicable.} | {Expected output.} | {Unexpected output.} | {Permissions, timing, or version limits.} |
+| Azure portal | {shown, not-evident, or absent} | {Azure Local, Arc, resource health, updates, or other blade.} | {Expected status.} | {Unexpected status.} | {Portal refresh or data delay.} |
+| Windows event logs | {shown, not-evident, or absent} | {Log name, provider, and Event ID.} | {Expected event or absence.} | {Important event.} | {Retention and clock-skew limits.} |
+| Example, Windows event logs | shown | Event Viewer or `Get-WinEvent` for a named provider and Event ID. | The event is absent, informational, or matches the documented healthy state. | The event appears within the article's time window with the documented abnormal value. | Event logs can roll over and node clocks can differ. |
+| Cluster logs | {shown, not-evident, or absent} | {Relevant `Get-ClusterLog` component or state.} | {Expected entry or not-evident rationale.} | {Unexpected entry.} | {Collection window and noise limits.} |
+| Windows Failover Cluster Manager | {shown, not-evident, or absent} | {Role, resource, network, or node view.} | {Expected status or not-evident rationale.} | {Unexpected status.} | {May not show component-specific state.} |
+| Windows Admin Center on a standalone host | {shown, not-evident, or absent} | {Where to check.} | {Expected status or not-evident rationale.} | {Unexpected status.} | {Extension and version limits.} |
+| Windows Admin Center in the Azure portal | {shown, not-evident, or absent} | {Where to check.} | {Expected status or not-evident rationale.} | {Unexpected status.} | {Access and refresh limits.} |
+| Component or tool log files on disk | {shown, not-evident, or absent} | {Path to component logs or generated reports.} | {Expected entry.} | {Unexpected entry.} | {Log rotation and privacy considerations.} |
+
+## Case-ready evidence and source authority
+
+Use this section when the article may support a support case, escalation, partner handoff, or OEM handoff.
+
+### Evidence package checklist
+
+| Artifact type | Collect | Sanitize before sharing | Used for |
+| --- | --- | --- | --- |
+| Timeline | {Coordinated Universal Time (UTC) start time, detection time, action time, and recovery time.} | {Remove personal names unless needed for support routing.} | {Correlates symptoms, actions, and validation.} |
+| Product and version evidence | {Azure Local version, OS build, extension version, firmware or driver version if relevant.} | {Remove serial numbers unless the OEM support path requires them.} | {Confirms applicability and supported versions.} |
+| Observability output | {Logs, events, command output, portal status, or screenshots named in the evidence table.} | {Remove tenant IDs, subscription IDs, secrets, and customer-specific names.} | {Confirms the scenario and rules out adjacent causes.} |
+| Configuration snapshot | {Relevant settings before and after an action.} | {Remove credentials, keys, tokens, and private endpoints.} | {Proves pre-check, rollback, and verification states.} |
+| Handoff summary | {Owner, lane, stop condition reached, and requested decision.} | {Keep only information needed for the next owner.} | {Prevents the next team from repeating discovery work.} |
+
+### Source-of-truth table
+
+| Mechanism claim | Evidence authority | Validation status | Notes |
+| --- | --- | --- | --- |
+| {Important mechanism, dependency, boundary, or limitation.} | {Public Microsoft documentation, product output, command output, event log, or lab validation.} | {Validated, partially validated, not validated, or not applicable.} | {What would disprove the claim or where it does not apply.} |
+
+### Ownership and vendor boundary
+
+| Boundary | Microsoft-owned evidence | OEM, partner, or customer-owned evidence | Handoff criteria |
+| --- | --- | --- | --- |
+| Product behavior | {Azure Local documentation, Azure portal status, PowerShell output, or event logs.} | {Customer configuration or partner deployment notes.} | {Escalate to Microsoft Support when product output contradicts documented behavior or the stop condition is reached.} |
+| Hardware or firmware | {Azure Local signals showing the hardware-facing symptom, if any.} | {Firmware setting, BIOS setting, baseboard management controller (BMC) logs, driver package, qualified configuration, or OEM support bundle.} | {Hand off to the OEM when the required evidence points to firmware, driver, device health, or unsupported hardware state.} |
+| Network or site infrastructure | {Azure Local network symptoms and affected nodes or adapters.} | {Switch configuration, firewall policy, Domain Name System (DNS), proxy, cabling, or site routing evidence.} | {Hand off to the network or site owner when Azure Local evidence shows dependency failure outside the cluster.} |
+
+## Operational boundaries and safety
+
+{Explain whether this Deep Dive is explanation-only or includes operational actions. If it includes actions, keep them safe for production and use the action pattern below.}
+
+- Risk labels: use exactly one of [LOW RISK], [MEDIUM RISK], or [HIGH RISK] for every action that may change state.
+- Required privilege and security impact: {State the least privilege needed and whether the action touches identity, Role-Based Access Control (RBAC), certificates, firewall rules, secrets, or tenant resources.}
+- Workload impact: {State whether the action can affect virtual machines (VMs), storage, networking, updates, quorum, Azure Arc connectivity, or customer workloads. Quorum means the cluster vote majority needed to keep cluster services online. Azure Arc is the Azure management connection for hybrid resources.}
+- Maintenance and approval gate: {State whether a maintenance window, change approval, customer approval, or workload-owner approval is required before any state-changing action.}
+- Do-not-proceed gates: {List conditions where the reader must stop and collect more evidence or escalate.}
+- Rollback or recovery boundary: {Explain what can be undone, what cannot be undone, and who owns recovery.}
+- Escalation: {State when to contact Microsoft Support, the product group, a partner, or an OEM vendor.}
+
+## Action pattern, if this article includes steps
+
+If this Deep Dive includes any command, configuration change, portal action, or mitigation example, use this pattern for each action. Do not omit any column.
+
+| Step | Action type | Risk label | Required privilege and security impact | Workload or maintenance gate | Pre-check | Action | Expected result or output | Stop condition and escalation | Rollback and expected rollback output | Rollback verification | Final verification |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| {Step name} | {[READ-ONLY] or state-changing.} | {Not applicable for [READ-ONLY]. For state-changing actions, use [LOW RISK], [MEDIUM RISK], or [HIGH RISK].} | {Least privilege required and security posture touched, such as RBAC, certificate, firewall, identity, or secret.} | {Maintenance window, customer approval, workload-owner approval, or "none expected" with evidence.} | {Read-only check that proves the action is applicable and safe.} | {One action only. Use placeholders, not real customer values.} | {Exact success output, status, or observable result.} | {Condition that means stop, do not retry blindly, and escalate or gather more evidence, plus the escalation owner.} | {How to undo the action or recover safely, and the expected rollback output or status.} | {Read-only check proving rollback restored the prior state.} | {Read-only check that confirms the intended state.} |
+| Example, read-only inventory | [READ-ONLY] | Not applicable. | Reader access to the target cluster, no security posture change. | No maintenance window expected because the action is read-only. | Confirm the reader has the required role and is connected to the intended cluster. | Run the read-only inventory command or open the documented portal blade. | Output shows the product, version, component state, and timestamp described in this article. | Output is missing, stale, from the wrong cluster, or shows an unexpected state that changes the scenario. Escalate to the article owner or Microsoft Support with the evidence package. | No rollback needed for read-only inventory. Expected rollback output is not applicable. | Not applicable because no state changed. | Repeat the same read-only check after any later action and compare the timestamp and state. |
+
+## Validation
+
+{State how the article was validated. Include what was tested, what was not tested, and how a reader can validate the claims in their environment.}
+
+| Claim or procedure | Validation method | Result | Evidence | Gaps |
+| --- | --- | --- | --- | --- |
+| {Claim, explanation, or action.} | {Documentation review, lab run, command output, log evidence, or not validated.} | {Pass, fail, not applicable, or not assessed.} | {Public documentation link, sanitized output, or artifact reference.} | {Known uncertainty or future validation needed.} |
+
+### Verify the fix or validate the guidance
+
+{For explanation-only content, describe how the reader validates that they understood the topic and selected the right next step. For operational content, describe the final read-only verification that proves the action reached the intended state.}
+
+## Future test automation metadata
+
+Use this section to make future TSG-FORGE automation possible. Keep placeholders until the article is assessed.
+
+| Field | Value |
+| --- | --- |
+| Automation candidate | {yes, no, or unknown.} |
+| `detector.type` | {none, envchecker, eventlog, command, service, feature, registry, telemetry, manual, portal, or control-plane.} |
+| Detector signal | {Exact check name, Event ID, command, service, feature, registry key, telemetry table, or manual surface.} |
+| `validation.reproduction_substrate` | {none, vm, hardware, or either. Use only these schema values.} |
+| Special fixture note | {Plain-language detail for a lab fixture, scratch object, cluster shape, or manual condition, if any. This is not a `validation.reproduction_substrate` value.} |
+| Current fidelity level | {L0, L1, L2, L3, or L4.} |
+| Technical grade | {Use null in the JSON metadata marker until TSG-FORGE produces A, B, C, or F. This is the authoritative technical grade field for README indexes and companion evidence.} |
+| Automation status | {not-assessed, scaffold, ready, proven, blocked, or manual.} |
+| Last validated | {Use YYYY-MM-DD after validation, or null in the JSON metadata marker when not validated.} |
+| Execution surface | {on-device, mixed, cloud-diagnostic, cloud-control, or thin. This is separate from automation status.} |
+| Spec reference | {Path to future companion spec, or blank.} |
+
+Plain-language detector explanation: describe what evidence source the selected detector represents and why it matches the article. When `detector.type` is `none`, keep `detector.signal` as JSON `null`. When selecting any other detector type, set both `detector.type` and `detector.signal` together so automation can find the exact signal.
+
+### Automation vocabulary
+
+Automation status records test readiness. It is separate from execution surface terms such as on-device, cloud, or mixed, which describe where a generated action can run.
+
+| Vocabulary | Values | Meaning |
+| --- | --- | --- |
+| Fidelity level | L0 | Static structure, metadata, and persona review only. No live validation. |
+| Fidelity level | L1 | Read-only diagnostics or claims were run or checked against a real or authoritative source. |
+| Fidelity level | L2 | A safe proxy, synthetic input, or data-source override exercised the same decision path without reproducing the full real-world failure. |
+| Fidelity level | L3 | A scratch object or isolated fixture exercised the real mechanism without changing the whole system. |
+| Fidelity level | L4 | Full inject, detect, mitigate, and revalidate loop was proven end to end on an appropriate lab substrate. |
+| Technical grade | null | No TSG-FORGE technical grade has been produced yet. |
+| Technical grade | A, B, C, or F | The authoritative TSG-FORGE technical grade, backed by report or spec evidence. Do not invent a separate grade vocabulary. |
+| Detector type | none | No machine detector applies yet. Use with `detector.signal: null`. |
+| Detector type | envchecker | Azure Local Environment Validator result or health-check signal. |
+| Detector type | eventlog | Windows event log provider, log name, and Event ID. |
+| Detector type | command | Read-only command or script result. |
+| Detector type | service, feature, registry | Operating system state probe for a service, Windows feature, or registry value. |
+| Detector type | telemetry | Fleet or service telemetry query used by internal validation. |
+| Detector type | manual or portal | Human-observed portal, visual, or manual validation surface. |
+| Detector type | control-plane | Azure Resource Manager or other Azure control-plane state. |
+| Automation status | not-assessed | No automation assessment has been completed. |
+| Automation status | scaffold | Metadata exists, but detector or validation automation is incomplete. |
+| Automation status | ready | Automation is authored and ready to run, but not yet proven. |
+| Automation status | proven | Automation has successful validation evidence and a validation date. |
+| Automation status | blocked | Automation is known to be blocked, with the blocking reason documented. |
+| Automation status | manual | Validation intentionally requires human judgment or an external manual step. |
+
+## References
+
+- {Public Microsoft Learn or Microsoft documentation link. Example: https://learn.microsoft.com/azure/azure-local/}

--- a/TSG/Templates/HowTo-Template.md
+++ b/TSG/Templates/HowTo-Template.md
@@ -1,109 +1,516 @@
+<!-- tsg-metadata
+{
+  "schema": "azure-local-supportability/tsg-metadata/v1",
+  "document_type": "how-to",
+  "products": ["replace-me"],
+  "detector": {
+    "type": "none",
+    "signal": null
+  },
+  "validation": {
+    "fidelity_level": "L0",
+    "technical_grade": null,
+    "reproduction_substrate": "none",
+    "automation_status": "not-assessed",
+    "last_validated": null,
+    "spec_ref": ""
+  }
+}
+-->
 <!--
-HowTo Template
-- Focus on providing clear, actionable step-by-step instructions for management operations
-- Explain the purpose and benefits of following this guide
-- Replace all {placeholders} with relevant content
-- This template provides a suggested structure - adapt it to make sense for your specific content
-    - The goal is clarity and usability for the reader
-
-Styling
-- Images should be placed in the `./images` folder and referenced
-- Any code block or JSON should be wrapped in triple backticks (```) with language identifier
-- References to Azure Local public documentation should always direct to the latest version
-- Use numbered lists for sequential steps and bullet points for options/notes
-
-You can use this regex to find placeholders that need to be replaced (search by Regex in your editor): \{([^}]+)\}
+How-To Template
+- Use this template for planned Azure Local management tasks, configuration changes, deployment steps, or operational procedures.
+- Replace every {placeholder} before publishing. Search with this regex: \{([^}]+)\}
+- Use numbered lists for sequential actions and bullets for options or notes.
+- Place images in an ./images folder and reference them from the article.
+- Use fenced code blocks with a language identifier for commands, output, JSON, XML, YAML, or logs.
+- External links must point to public Microsoft documentation, preferably the latest Azure Local docs.
+- Do not publish customer identifiers, tenant identifiers, subscription identifiers, secrets, tokens, or private Microsoft links.
 -->
 
 # {Title}
 
 <table border="1" cellpadding="6" cellspacing="0" style="border-collapse:collapse; margin-bottom:1em;">
   <tr>
-    <th style="text-align:left; width: 180px;">Component</th>
-    <td><strong>{Component Name}</strong></td>
+    <th style="text-align:left; width: 220px;">Document type</th>
+    <td><strong>How-To</strong></td>
   </tr>
   <tr>
-    <th style="text-align:left; width: 180px;">Topic</th>
-    <td><strong>{Topic Name}</strong>: {Brief description of the how to}</td>
+    <th style="text-align:left; width: 220px;">Purpose</th>
+    <td>{State the customer or operator outcome this guide helps achieve and why it matters.}</td>
   </tr>
   <tr>
-    <th style="text-align:left; width: 180px;">Applicable Scenarios</th>
-    <td><strong>{Applicable Scenarios}</strong>: {List of scenarios this guide applies to}</td>
+    <th style="text-align:left; width: 220px;">Business impact</th>
+    <td>{State the customer capability, workload, deployment, or operations outcome this procedure protects or restores.}</td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 220px;">Audience</th>
+    <td>{Primary reader or owner, such as Azure Local administrator, Microsoft Customer Support Services (CSS) engineer, partner or system integrator (SI) deployment engineer, original equipment manufacturer (OEM) field engineer, or workload owner.}</td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 220px;">Owner and approver</th>
+    <td>{Execution owner, approval owner, and handoff team if the assigned reader is not the owner.}</td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 220px;">Component</th>
+    <td>{Azure Local component or feature area.}</td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 220px;">Applicable products</th>
+    <td>{List exact Azure Local products, SKUs, deployment types, and related Microsoft products. Verify against public documentation before publishing.}</td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 220px;">Supported versions</th>
+    <td>{List supported Azure Local releases, builds, extension versions, firmware versions, or tool versions. State the source used to verify support.}</td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 220px;">Applies to</th>
+    <td>{List environments, cluster states, operations, and scenarios where this guide applies.}</td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 220px;">Does not apply to</th>
+    <td>{List explicit out-of-scope products, versions, symptoms, or conditions. Tell the reader where to go instead.}</td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 220px;">Estimated duration</th>
+    <td>{Expected operator time and elapsed time. Include whether the task needs a maintenance window.}</td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 220px;">Overall action type and risk</th>
+    <td>{Use [READ-ONLY] when the guide only gathers information and state that risk is not applicable because no state changes. For state-changing guides, choose one: [LOW RISK], [MEDIUM RISK], [HIGH RISK]. Explain the reason in one sentence.}</td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 220px;">Customer update cadence</th>
+    <td>{Who receives updates, how often they receive them, and the next update time if the procedure takes longer than expected.}</td>
   </tr>
 </table>
 
 ## Overview
 
-{Brief description of what this guide will help the reader accomplish}
+{Briefly describe the task, the end state, and the benefit to the customer or operator. Keep this section short enough for a decision maker to skim.}
 
-## What and Why
+## Decision summary
 
-### What This Guide Covers
+Fill this summary before the first command so leaders, account teams, and field engineers can make the same proceed or stop decision.
 
-{Clearly describe what specific configuration, setup, or management task is covered by this guide}
+| Decision field | Required author input |
+| --- | --- |
+| Owner | {Person, team, or role that runs the procedure.} |
+| Approver | {Person, team, or role that approves the maintenance window or state change.} |
+| Customer impact | {Plain-language statement of what customer capability is affected now and what capability is restored after success.} |
+| Fastest safe unblock | {Shortest approved path, first stop condition, and fallback owner if the path is not safe.} |
+| Proceed decision | {Proceed only when prerequisites, approvals, rollback, and evidence capture are ready. Name the approver.} |
+| Next customer update | {Time, audience, and content for the next update.} |
+| Success statement | {One sentence the support or account team can use to explain that the capability is restored.} |
 
-### When to Use This Guide
+## Outcome
 
-{Describe the scenarios or conditions under which this guide should be followed}
+After completing this guide, the reader should be able to:
+
+- {Outcome 1 with a measurable result.}
+- {Outcome 2 with a measurable result.}
+- {Completion signal that proves the task succeeded.}
+
+## Scope and routing
+
+Use this guide only when all of the following are true:
+
+- {In-scope condition 1.}
+- {In-scope condition 2.}
+- {Required product or version condition.}
+
+Do not use this guide when any of the following are true:
+
+- {Out-of-scope condition 1.}
+- {Out-of-scope condition 2.}
+- {Escalation or handoff condition, such as original equipment manufacturer (OEM)-owned firmware work, network-team ownership, or product-group investigation.}
+
+If the guide is assigned to the wrong owner, collect this handoff evidence before sending it to the owning team.
+
+| Handoff scenario | Owning team or role | Evidence to collect before handoff | Handoff trigger |
+| --- | --- | --- | --- |
+| Network-owned change | {Network team or partner.} | {Adapter names, switch ports, IP configuration, route or DNS output, and timestamp.} | {Condition that proves the issue is network-owned.} |
+| OEM-owned hardware or firmware change | {OEM vendor field engineer.} | {Platform model, firmware levels, baseboard management controller (BMC), integrated Dell Remote Access Controller (iDRAC), or HPE Integrated Lights-Out (iLO) evidence, and supported configuration source.} | {Condition that requires OEM action.} |
+| Workload-owned change | {Application or virtual machine (VM) owner.} | {Affected VM or workload list, expected outage, drain status, and approval.} | {Condition that requires workload-owner approval.} |
+| Microsoft support or product escalation | {Microsoft CSS or product group.} | {Logs, command outputs, error text, timestamps, versions, and failed verification result.} | {Condition that blocks safe customer action.} |
+
+Document safe alternatives and rejected approaches so the reader knows what not to try.
+
+| Option | Status | Why it is safe, preferred, or rejected | Evidence or approval needed |
+| --- | --- | --- | --- |
+| {Preferred safe path} | {Use} | {Why this is the lowest-risk approved path.} | {Required evidence or approval.} |
+| {Alternative path} | {Use only when...} | {Tradeoff, added risk, or prerequisite.} | {Required evidence or approval.} |
+| {Rejected approach} | {Do not use} | {Why this approach is unsafe, unsupported, untested, or outside the guide scope.} | {Who can approve or replace it, if anyone.} |
 
 ## Prerequisites
 
-{List any requirements, permissions, or setup needed before starting}
+Complete these checks before starting. Do not proceed until every required item is satisfied.
 
-- {Prerequisite 1}
-- {Prerequisite 2}
+| Prerequisite | Required value or condition | How to check | Stop condition |
+| --- | --- | --- | --- |
+| Permissions | {Role, role-based access control (RBAC) assignment, local admin right, or tool access required.} | {Command, portal page, or public documentation link.} | {Stop if permission is missing.} |
+| Cluster health | {Required health state, quorum state, update state, or node state.} | {Command or portal page to verify.} | {Stop if health state is not safe for this task.} |
+| Backup or recovery material | {Backup, recovery key, config export, or rollback artifact required.} | {How to confirm it exists and is usable.} | {Stop if recovery material is unavailable.} |
+| Maintenance window | {Required or not required. Include duration and customer communication needs.} | {How to confirm approval.} | {Stop if required approval is missing.} |
+| Tools and versions | {PowerShell modules, Azure CLI extensions, browser, portal access, firmware package, or vendor utility.} | {Command to show version or public Microsoft link.} | {Stop if an unsupported tool version is present.} |
 
-## Table of Contents
+## Safety and impact
 
-{Update Table of Contents as needed}
+Classify each action before it appears in this guide:
+
+- [READ-ONLY]: Diagnostics, checks, and information gathering that do not change state. Risk is not applicable because no state changes.
+- [LOW RISK]: State-changing actions with no expected customer workload impact and a documented rollback.
+- [MEDIUM RISK]: State-changing actions that can affect management operations, validation results, or a single node, but should not interrupt running workloads when prerequisites are met.
+- [HIGH RISK]: State-changing actions that can interrupt workloads, require node drain or reboot, alter security posture, modify firmware, delete resources, or require coordinated maintenance.
+
+Document the maintenance impact before any action that changes state:
+
+| Impact area | Author prompt |
+| --- | --- |
+| Workloads and virtual machines (VMs) | {Can this affect VM availability, live migration, storage paths, network connectivity, or application traffic?} |
+| Cluster availability | {Does this require draining a node, rebooting, changing quorum-sensitive state, or pausing an update?} |
+| Security posture | {Does this change authentication, certificates, BitLocker, Secure Boot, Defender, firewall, RBAC, or secrets?} |
+| OEM or partner ownership | {Is this owned by an OEM, networking team, partner SI, Microsoft CSS, or customer IT?} |
+| Customer communication | {Who must be notified, what duration should they expect, and what completion signal should they receive?} |
+
+## Glossary and do-not-proceed checklist
+
+Add short definitions for terms that a first-time Azure Local operator must understand before running commands.
+
+| Term | Plain-language definition | Where the reader verifies it |
+| --- | --- | --- |
+| Role-based access control (RBAC) | {Define the Azure permission model or role assignment needed for this procedure.} | {Command, portal surface, or public Microsoft documentation link.} |
+| Quorum | {Define the minimum cluster voting state needed to keep the cluster available.} | {Command, portal surface, or public Microsoft documentation link.} |
+| Microsoft Customer Support Services (CSS) | {Define when Microsoft support owns the next action.} | {Escalation or support handoff link.} |
+| System integrator (SI) | {Define when a deployment partner owns the next action.} | {Partner handoff process.} |
+| Original equipment manufacturer (OEM) | {Define when the hardware vendor owns the next action.} | {Vendor support path or public Microsoft hardware guidance.} |
+
+Do not proceed unless every row below is satisfied.
+
+| Guardrail | Required proof before continuing | If not satisfied |
+| --- | --- | --- |
+| All placeholders are replaced | {Every placeholder has a real customer-safe value or a documented reason it is not used.} | Stop and complete the filled-in variables table. |
+| Target scope is clear | {State whether the action affects one node, all nodes, one cluster, a resource group, a subscription, or a tenant.} | Stop and get owner approval for the correct scope. |
+| Workload impact is approved | {VM, app, network, security, and maintenance impact are documented.} | Stop and obtain the required approval or handoff. |
+| Rollback is ready | {Rollback command, portal action, or support path is documented and available.} | Stop unless the approver accepts that rollback is not possible. |
+| Expected output is known | {Normal output and stop-condition output are documented.} | Stop and add expected output before running the action. |
+
+## Table of contents
 
 - [Overview](#overview)
-- [What and Why](#what-and-why)
+- [Decision summary](#decision-summary)
+- [Outcome](#outcome)
+- [Scope and routing](#scope-and-routing)
 - [Prerequisites](#prerequisites)
-- [{Section 1 Title}](#section-1-title)
+- [Safety and impact](#safety-and-impact)
+- [Glossary and do-not-proceed checklist](#glossary-and-do-not-proceed-checklist)
+- [Execution contract](#execution-contract)
+- [{Procedure section title}](#procedure-section-title)
+- [Rollback](#rollback)
 - [Verification](#verification)
+- [Expected output examples](#expected-output-examples)
 - [Troubleshooting](#troubleshooting)
+- [Handoff and escalation package](#handoff-and-escalation-package)
+- [Evidence to collect](#evidence-to-collect)
+- [Claims and validation evidence](#claims-and-validation-evidence)
+- [Metadata vocabulary](#metadata-vocabulary)
+- [Future test automation metadata](#future-test-automation-metadata)
+- [Next steps](#next-steps)
+- [References](#references)
 
-## {Section 1 Title}
+## Execution contract
 
-{Brief explanation of this scenario or configuration. Add as many sections as needed. An example might be: 1 Node Cluster vs 4 Node Cluster or Update vs Add Node}
+Complete this contract before the procedure. It is the compact checklist for literal followers, multi-node rollouts, workload owners, and reviewers.
 
-### Step 1: {Action Description}
+### Filled-in variables and target scope
 
-{Brief explanation of what this step accomplishes}
+| Placeholder or variable | Exact value to use | Target scope | Current value | New value | Approval owner | Verification command or surface |
+| --- | --- | --- | --- | --- | --- | --- |
+| {Placeholder 1} | {Value to use.} | {Node, cluster, resource group, subscription, tenant, site, or workload.} | {Current value or state.} | {New value or state.} | {Approver.} | {Command or UI surface.} |
+| {Placeholder 2} | {Value to use.} | {Node, cluster, resource group, subscription, tenant, site, or workload.} | {Current value or state.} | {New value or state.} | {Approver.} | {Command or UI surface.} |
 
-1. {Detailed instruction}
+### Action checklist
 
-2. {Next instruction}
+Every generated action must complete each row. Use [READ-ONLY] for diagnostics and state that risk is not applicable because no state changes. Use risk labels only for state-changing actions.
 
-### Step 2: {Action Description}
+| Required item | Author prompt |
+| --- | --- |
+| Action type | {Use [READ-ONLY] for diagnostics or information gathering. Use state-changing when the action modifies configuration, data, resources, firmware, or workload state.} |
+| Risk label for state-changing action | {Required only when action type is state-changing. Choose one: [LOW RISK], [MEDIUM RISK], or [HIGH RISK]. For [READ-ONLY], write "not applicable, no state changes."} |
+| Privilege required | {Least-privilege role, RBAC assignment, local right, or tool access required for this action.} |
+| Workload impact | {State whether the action affects VM uptime, app traffic, live migration, storage paths, networking, security posture, or update flow.} |
+| Drain or maintenance approval | {State whether VM drain, node pause, reboot, maintenance window, or customer approval is required.} |
+| Pre-check | {Read-only command or UI surface that proves the target is safe to change.} |
+| Action | {One command or UI action, with placeholders replaced.} |
+| Error handling and retry behavior | {State ErrorAction or equivalent behavior, retry count, delay, and when a retry is unsafe.} |
+| Idempotency | {State whether it is safe to run the action more than once and how the command detects existing state.} |
+| Expected result or output | {Exact success output, status, or portal state.} |
+| Stop condition | {Exact failure output, unexpected state, or blast-radius concern that stops the procedure.} |
+| Rollback | {Undo command, portal action, or support path.} |
+| Expected rollback output | {Exact output or state that proves the rollback action ran.} |
+| Rollback verification | {Read-only command or UI surface that proves the previous state is restored.} |
+| Verification | {Read-only command or UI surface that proves the step succeeded.} |
+| Escalation | {Owner to contact if action, rollback, or verification fails.} |
 
-{Brief explanation of what this step accomplishes}
+### Rollout tracker
 
-1. {Detailed instruction}
+Use this tracker when the procedure repeats across nodes, clusters, resource groups, or sites.
 
-2. {Next instruction}
+| Batch or site | Targets | Order | Pre-validation | Approved window | Re-run validation | Stop criteria | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| {Batch 1} | {Targets included.} | {Order and dependency.} | {Read-only validation before the batch.} | {Window and approver.} | {Validation after the batch.} | {When to stop before the next batch.} | {Not started, running, complete, or stopped.} |
+| {Batch 2} | {Targets included.} | {Order and dependency.} | {Read-only validation before the batch.} | {Window and approver.} | {Validation after the batch.} | {When to stop before the next batch.} | {Not started, running, complete, or stopped.} |
 
-### Verification
+## {Procedure section title}
 
-{Steps to confirm the configuration was completed successfully and is working as expected}
+{Explain the scenario or configuration this procedure covers. State whether the actions are per node, per cluster, per resource group, per subscription, or per tenant.}
 
-1. {Verification step 1}
+Repeat the following action pattern for every generated step. Every action must include action type, pre-check, action, expected result or output, stop condition, rollback, and verification. Use [READ-ONLY] for diagnostics and state that rollback and risk are not applicable because no state changes. Use [LOW RISK], [MEDIUM RISK], or [HIGH RISK] only for state-changing actions.
 
-2. {Verification step 2}
+### Step 1: {Action description}
 
-### Troubleshooting
+**Action type:** {Use [READ-ONLY] for diagnostics or information gathering and state that risk is not applicable because no state changes. Use state-changing when the action modifies configuration, data, resources, firmware, or workload state.}
 
-{Common issues and their solutions}
+**Risk label for state-changing action:** {Required only for state-changing actions. Choose one: [LOW RISK], [MEDIUM RISK], [HIGH RISK]. For [READ-ONLY], write "not applicable, no state changes."}
 
-#### {Common Issue 1}
+**Privilege required:** {Least-privilege role, RBAC assignment, local right, or tool access required for this step.}
 
-**Symptoms:** {Description of what the user might see}
-**Solution:** {How to resolve it}
+**Workload impact and approval:** {State VM, app, live migration, network, security, and maintenance impact. State whether drain, reboot, maintenance approval, or workload-owner approval is required.}
 
-##### {Common Issue 2}
+**Purpose:** {Explain what this step changes or confirms.}
 
-**Symptoms:** {Description of what the user might see}
-**Solution:** {How to resolve it}
+**Pre-check:** {Confirm the required state before this step. Include the command, portal page, or UI surface.}
 
----
+```powershell
+<# Replace with a read-only pre-check command, if this step uses PowerShell. #>
+{PreCheckCommand}
+```
+
+**Action:** {Give one clear action. If this is a command, use placeholders such as <ClusterName> or <ResourceGroupName> instead of real customer values.}
+
+```powershell
+<# Replace with the safe action command, if this step uses PowerShell. #>
+{ActionCommand}
+```
+
+**Error handling and retry behavior:** {State ErrorAction or equivalent behavior, retry count, retry delay, and when a retry is unsafe.}
+
+**Idempotency:** {State whether running this step more than once is safe and how the command checks existing state before changing it.}
+
+**Expected result or output:** {Show the expected success message, table values, portal state, or command output shape.}
+
+```text
+{ExpectedOutput}
+```
+
+**Stop condition:** {State the exact output, error, state, or risk signal that means the reader must stop before continuing.}
+
+**Rollback for this step:** {State how to undo this step if it fails or produces the wrong output. If no rollback exists, explain why and require approval before the action.}
+
+**Expected rollback output:** {Show the output, state, or portal value that proves rollback ran.}
+
+**Rollback verification:** {State the read-only command or UI surface that proves the previous state is restored.}
+
+**Verification for this step:** {State how to prove this single step succeeded before moving to the next step.}
+
+**Escalation:** {State who owns the next action if the step, rollback, or verification fails.}
+
+### Step 2: {Next action description}
+
+**Action type:** {Use [READ-ONLY] for diagnostics or information gathering and state that risk is not applicable because no state changes. Use state-changing when the action modifies configuration, data, resources, firmware, or workload state.}
+
+**Risk label for state-changing action:** {Required only for state-changing actions. Choose one: [LOW RISK], [MEDIUM RISK], [HIGH RISK]. For [READ-ONLY], write "not applicable, no state changes."}
+
+**Privilege required:** {Least-privilege role, RBAC assignment, local right, or tool access required for this step.}
+
+**Workload impact and approval:** {State VM, app, live migration, network, security, and maintenance impact. State whether drain, reboot, maintenance approval, or workload-owner approval is required.}
+
+**Purpose:** {Explain what this step changes or confirms.}
+
+**Pre-check:** {Confirm the required state before this step.}
+
+```powershell
+<# Replace with a read-only pre-check command, if this step uses PowerShell. #>
+{PreCheckCommand}
+```
+
+**Action:** {Give one clear action.}
+
+```powershell
+<# Replace with the safe action command, if this step uses PowerShell. #>
+{ActionCommand}
+```
+
+**Error handling and retry behavior:** {State ErrorAction or equivalent behavior, retry count, retry delay, and when a retry is unsafe.}
+
+**Idempotency:** {State whether running this step more than once is safe and how the command checks existing state before changing it.}
+
+**Expected result or output:** {Show the expected output or state.}
+
+```text
+{ExpectedOutput}
+```
+
+**Stop condition:** {State when to stop and who to contact.}
+
+**Rollback for this step:** {State how to undo this step or restore the previous state.}
+
+**Expected rollback output:** {Show the output, state, or portal value that proves rollback ran.}
+
+**Rollback verification:** {State the read-only command or UI surface that proves the previous state is restored.}
+
+**Verification for this step:** {State how to prove this step succeeded.}
+
+**Escalation:** {State who owns the next action if the step, rollback, or verification fails.}
+
+## Rollback
+
+Use this section if a step fails, the expected output does not match, the stop condition is reached, or the customer asks to return to the previous state.
+
+| Rollback trigger | Rollback action | Expected result or output | Verification after rollback |
+| --- | --- | --- | --- |
+| {Trigger 1} | {Command or portal action to restore the previous state.} | {Expected rollback output.} | {How to prove rollback succeeded.} |
+| {Trigger 2} | {Command or portal action to restore the previous state.} | {Expected rollback output.} | {How to prove rollback succeeded.} |
+
+If rollback is not possible, replace this section with the explicit reason, the approval required before proceeding, and the support or escalation path.
+
+## Verification
+
+Run these checks after the final step and after any rollback. The guide is not complete until every pass criterion is met.
+
+| Check | Command or UI surface | Expected result or output | Pass criteria | If it fails |
+| --- | --- | --- | --- | --- |
+| {Verification check 1} | {Command, portal page, or tool.} | {Expected output.} | {Exact values or state that prove success.} | {Rollback, retry, or escalation instruction.} |
+| {Verification check 2} | {Command, portal page, or tool.} | {Expected output.} | {Exact values or state that prove success.} | {Rollback, retry, or escalation instruction.} |
+
+## Expected output examples
+
+Use examples with placeholders only. Do not include customer identifiers, subscription identifiers, tenant identifiers, secrets, tokens, or private links.
+
+```text
+{Command or portal surface}
+Expected: {Expected success value, status, or message}
+Unexpected: {Unexpected value, status, or message that triggers a stop condition}
+```
+
+## Troubleshooting
+
+### {Common issue 1}
+
+**Symptoms:** {What the reader sees.}
+
+**Likely cause:** {Most likely cause, with evidence.}
+
+**Action:** {Safe next step. If it is diagnostic, label it [READ-ONLY] and state risk is not applicable because no state changes. If it changes state, use the same action contract as the procedure: action type, risk label, privilege, workload or maintenance gate, pre-check, action, expected result or output, stop condition, rollback, expected rollback output, rollback verification, verification, and escalation.}
+
+**Escalate when:** {Condition that requires Microsoft CSS, product group, OEM, network team, partner SI, or customer IT escalation.}
+
+### {Common issue 2}
+
+**Symptoms:** {What the reader sees.}
+
+**Likely cause:** {Most likely cause, with evidence.}
+
+**Action:** {Safe next step. If it is diagnostic, label it [READ-ONLY] and state risk is not applicable because no state changes. If it changes state, use the same action contract as the procedure: action type, risk label, privilege, workload or maintenance gate, pre-check, action, expected result or output, stop condition, rollback, expected rollback output, rollback verification, verification, and escalation.}
+
+**Escalate when:** {Condition that requires escalation.}
+
+## Handoff and escalation package
+
+Create this package when a mis-assigned reader needs to hand off the case or when verification fails after rollback.
+
+| Package item | Required detail |
+| --- | --- |
+| Summary | {One-line problem, impact, and current state.} |
+| Owner requested | {Network, OEM, workload owner, Microsoft CSS, product group, partner SI, or customer IT.} |
+| Evidence | {Logs, command outputs, portal screenshots, exact error text, and timestamps in UTC.} |
+| Environment | {Product, supported version, cluster state, node count, hardware model if relevant, and tool versions.} |
+| Actions already tried | {Pre-checks, actions, expected result, actual result, rollback status, and verification result.} |
+| Escalation trigger | {The condition that proves the current reader should not continue.} |
+| Redaction | {Customer identifiers, subscription identifiers, tenant identifiers, secrets, tokens, and private data removed.} |
+
+## Evidence to collect
+
+Collect enough evidence for support, audit, or PR review without exposing secrets or customer-private data.
+
+| Evidence | Where to collect it | Redaction required | Why it matters |
+| --- | --- | --- | --- |
+| {Evidence item 1} | {Command, portal page, event log, component log, or public tool.} | {Values to redact.} | {How this confirms success or explains failure.} |
+| {Evidence item 2} | {Command, portal page, event log, component log, or public tool.} | {Values to redact.} | {How this confirms success or explains failure.} |
+
+## Claims and validation evidence
+
+Use this table for mechanism statements, version requirements, safety claims, and rollback claims. Do not publish a technical claim without a source or validation status.
+
+| Claim | Source or evidence | Tested status | Failure mode covered | Rollback proof |
+| --- | --- | --- | --- | --- |
+| {Technical claim 1} | {Public Microsoft documentation, command output, lab validation, or product source summary that supports the claim.} | {Not tested, static-reviewed, read-only validated, lab validated, or customer validated.} | {What can go wrong if the claim is false or incomplete.} | {How rollback was tested or why rollback is not available.} |
+| {Technical claim 2} | {Public Microsoft documentation, command output, lab validation, or product source summary that supports the claim.} | {Not tested, static-reviewed, read-only validated, lab validated, or customer validated.} | {What can go wrong if the claim is false or incomplete.} | {How rollback was tested or why rollback is not available.} |
+
+## Metadata vocabulary
+
+Use these definitions when completing the metadata marker or the future test automation table. The public schema is [tsg-metadata.schema.json](../Templates/tsg-metadata.schema.json) for articles copied into a component folder under `TSG/<Component>/`. If the article is copied into a deeper folder, adjust the relative path so the link still reaches `TSG/Templates/tsg-metadata.schema.json`.
+
+| Field or value | Definition |
+| --- | --- |
+| detector.type `none` | No detector has been selected. Set `detector.signal` to JSON `null`. When authors select a detector later, they must set `detector.type` and `detector.signal` together. |
+| detector.type `command` | A read-only command or script detects the state. Set `detector.signal` to the command or function name. |
+| detector.type `envchecker` | An Azure Local Environment Checker validation detects the state. Set `detector.signal` to the validator or check name. |
+| detector.type `feature` | An installed Windows feature state detects the condition. Set `detector.signal` to the feature name. |
+| detector.type `portal` or `manual` | A human checks a portal or manual surface. Set `detector.signal` to the exact blade, page, or manual check. |
+| detector.type `eventlog`, `service`, `registry`, `telemetry`, or `control-plane` | A specific event, service state, registry value, telemetry query, or Azure control-plane state detects the condition. Set `detector.signal` to the exact signal. |
+| fidelity level `L0` | Static review only. No live command or detector proof. |
+| fidelity level `L1` | Read-only commands or verification steps were run and returned the claimed shape. |
+| fidelity level `L2` | The detection signal and reversible remediation direction were validated with a safe proxy or synthetic input. |
+| fidelity level `L3` | The real failure pattern was validated on an isolated scratch object or disposable target. |
+| fidelity level `L4` | Full inject, detect, mitigate, and revalidate loop was proven end to end on a safe lab substrate. |
+| technical_grade `null`, `A`, `B`, `C`, or `F` | Use JSON `null` until a TSG-FORGE grade exists. Use `A`, `B`, `C`, or `F` only when a grading artifact records that grade. This is separate from `fidelity_level`. |
+| safe injectability `none` | No safe inject is known. Keep fidelity at L0 or L1 unless read-only validation exists. |
+| safe injectability `proxy` | A safe substitute input exercises the same decision logic without causing the real failure. |
+| safe injectability `scratch object` | A temporary object, such as a test resource or file, carries the failure and can be deleted. |
+| safe injectability `reversible lab-only change` | A lab change can be undone and is not suitable for customer production. |
+| safe injectability `destructive` | The action is not safely reversible. Do not use it for live validation without explicit approval and a disposable target. |
+| automation_status `not-assessed` | No automation assessment has been performed. |
+| automation_status `scaffold` | Metadata exists, but the detector or automation is not ready to run. |
+| automation_status `ready` | Automation is defined and ready to run, but not yet proven. |
+| automation_status `proven` | Automation has passed validation and cites evidence. |
+| automation_status `blocked` | Automation is blocked by safety, access, substrate, or product limitations. |
+| automation_status `manual` | Validation remains manual by design. |
+| Execution surface | Where an action runs: `on-device`, `mixed`, `cloud-diagnostic`, `cloud-control`, or `thin`. Do not put execution-surface values in `automation_status`. |
+
+## Future test automation metadata
+
+Complete this section so TSG-FORGE or another validation harness can evaluate this How-To later.
+
+| Field | Required author input |
+| --- | --- |
+| Metadata schema | Link to [tsg-metadata.schema.json](../Templates/tsg-metadata.schema.json). Adjust the relative path if the article is copied into a deeper folder. |
+| Automation candidate | {yes, no, or partial. Explain why.} |
+| detector.type | {Choose the exact JSON detector type: none, command, control-plane, envchecker, eventlog, feature, manual, portal, registry, service, or telemetry. Use the adjacent explanation columns or notes for plain-language validation-surface details.} |
+| Automation status | {Choose one: not-assessed, scaffold, ready, proven, blocked, or manual. Do not use execution-surface values here.} |
+| Technical grade | {Use null until graded, or A, B, C, or F after a TSG-FORGE grading artifact exists.} |
+| Safe injectability | {none, proxy, scratch object, reversible lab-only change, or destructive.} |
+| Rollback automation | {How rollback could be automated and what state it restores.} |
+| Reproduction substrate | {Choose one: none, vm, hardware, or either. Use none with automation_status manual when validation is intentionally manual.} |
+| Target fidelity level | {L0, L1, L2, L3, or L4.} |
+| validation.last_validated | {Use JSON null until validation has run. After validation, use the ISO date in YYYY-MM-DD format and cite the report, spec, or evidence.} |
+| Validation history | {Date, build, substrate, result, and evidence link when available.} |
+| Spec reference | {Path to future companion spec, if one exists.} |
+
+## Next steps
+
+After verification passes, state what happens next so the work is closed cleanly.
+
+| Next step | Required author input |
+| --- | --- |
+| Monitor | {Signals, logs, portal surfaces, or customer symptoms to watch after completion, and for how long.} |
+| Close or hand back | {Who accepts the result, what evidence they receive, and how the task is closed or returned to the owning team.} |
+| Follow-up work | {Any deferred cleanup, documentation, ticket update, support handoff, or future automation item.} |
+| Customer update | {Plain-language completion note, remaining risk, and next update cadence if monitoring continues.} |
+
+## References
+
+Add only public Microsoft links, such as:
+
+- [Azure Local documentation](https://learn.microsoft.com/azure/azure-local/)
+- {Public Microsoft documentation link for this task}

--- a/TSG/Templates/Markdown-Snippets.md
+++ b/TSG/Templates/Markdown-Snippets.md
@@ -445,7 +445,7 @@ python3 <path-to-tsg-pr-review>/scripts/lint_tsg.py <article-file>
 
 | Check | Command | Result | Report path or output |
 | --- | --- | --- | --- |
-| TSG-FORGE lint | `python3 <path-to-tsg-forge>/harness.py --lint --tsg <article-file>` | <A, B, F, or not run> | <report path> |
+| TSG-FORGE lint | `python3 <path-to-tsg-forge>/harness.py --lint --tsg <article-file>` | <A, B, C, F, or not run> | <report path> |
 | Deterministic PR lint | `python3 <path-to-tsg-pr-review>/scripts/lint_tsg.py <article-file>` | <zero findings, or finding count> | <output path or pasted JSON> |
 ```
 

--- a/TSG/Templates/Markdown-Snippets.md
+++ b/TSG/Templates/Markdown-Snippets.md
@@ -1,40 +1,489 @@
 # Markdown Formatting Reference
 
-This document provides copy-paste snippets for common formatting elements used in Azure Local Supportability documentation.
+This document provides copy-ready snippets for common formatting elements used in Azure Local Supportability documentation. It is a reference authoring aid, not an article template. Copy the sections you need into a troubleshooting guide, how-to guide, reference, overview, or deep dive. In this file, TSG means troubleshooting guide.
+
+Use text labels in addition to any visual styling. Do not use icons as the only status signal.
 
 ---
 
-## Alert & Emphasis Boxes
+## Table of Contents
 
-### Important Information
+- [Article metadata marker](#article-metadata-marker)
+- [Applicable products and supported versions](#applicable-products-and-supported-versions)
+- [Risk and safety labels](#risk-and-safety-labels)
+- [Prerequisites and stop gates](#prerequisites-and-stop-gates)
+- [Author assembly checklist](#author-assembly-checklist)
+- [Complete action pattern](#complete-action-pattern)
+- [Expected output and validation](#expected-output-and-validation)
+- [Where this appears](#where-this-appears)
+- [Test automation metadata](#test-automation-metadata)
+- [Owner, impact, and handoff snippets](#owner-impact-and-handoff-snippets)
+- [Worked safe-action and rollout snippets](#worked-safe-action-and-rollout-snippets)
+- [Evidence, glossary, and validation snippets](#evidence-glossary-and-validation-snippets)
+- [Alert and emphasis boxes](#alert-and-emphasis-boxes)
+- [Mermaid Markdown diagrams and flow charts](#mermaid-markdown-diagrams-and-flow-charts)
+- [Optional HTML callout boxes](#optional-html-callout-boxes)
+- [Code blocks](#code-blocks)
+- [Tables](#tables)
+- [Status labels](#status-labels)
+
+---
+
+## Article metadata marker
+
+Article templates and finished articles should include exactly one HTML-comment JSON marker. Keep this marker near the top of the article, then replace the placeholder values. Component README and CONTRIBUTING templates should require and index this marker, but should not embed article metadata themselves.
+
+````markdown
+<!-- tsg-metadata
+{
+  "schema": "azure-local-supportability/tsg-metadata/v1",
+  "document_type": "replace-me",
+  "products": ["replace-me"],
+  "detector": {"type":"none","signal":null},
+  "validation": {"fidelity_level":"L0","technical_grade":null,"reproduction_substrate":"none","automation_status":"not-assessed","last_validated":null,"spec_ref":""}
+}
+-->
+````
+
+Validate the completed marker against [`tsg-metadata.schema.json`](./tsg-metadata.schema.json). Keep `validation.technical_grade` as JSON `null` until TSG-FORGE produces `A`, `B`, `C`, or `F` with report or spec evidence. When `detector.type` is `none`, keep `detector.signal` as JSON `null`. When an author selects a real detector, such as `envchecker`, `eventlog`, or `command`, they must set both `detector.type` and `detector.signal` together.
+
+---
+
+## Applicable products and supported versions
+
+Use this table whenever guidance depends on product, release, hardware, or operation phase. Be explicit about supported versions and out-of-scope cases.
+
+```markdown
+## Applicable products
+
+| Product | Supported versions | Scope | Out of scope | Source |
+| --- | --- | --- | --- | --- |
+| Azure Local | <supported Azure Local version or solution build> | <deployment, add node, update, upgrade, or runtime> | <older builds, newer builds, or unrelated components> | <public Microsoft Learn link or product-emitted evidence> |
+| <original equipment manufacturer (OEM) or component, if applicable> | <firmware, driver, or software version> | <node, cluster, switch, baseboard management controller (BMC), disk, or workload> | <unsupported hardware or configuration> | <public Microsoft link or product-emitted evidence> |
+```
+
+---
+
+## Risk and safety labels
+
+Use `[READ-ONLY]` for steps that do not change state. It is not a risk label. When an action may change state, use one of the canonical risk labels and replace the placeholders with the actual impact, gate, and rollback for the article.
+
+```markdown
+## Risk and safety
+
+> [!WARNING]
+> [<READ-ONLY|LOW RISK|MEDIUM RISK|HIGH RISK>] This action changes <state, service, configuration, workload placement, or firmware>, or is read-only. Expected impact: <none, brief reconnect, workload failover, reboot, or downtime>. Do not continue unless <precondition> is true, <required privilege> is present, <maintenance window or approval> is satisfied for the workload impact, and <rollback or backup> is available.
+
+| Label | When to use | Required pre-check | Required privilege | Workload or maintenance gate | Stop condition | Rollback |
+| --- | --- | --- | --- | --- | --- | --- |
+| [READ-ONLY] | Non-mutating detection or validation only | <command or observable condition> | <least privilege required> | <none, or state why no maintenance window is needed> | <what means do not proceed> | Not applicable because no state changes |
+| [LOW RISK] | Reversible changes with no expected workload impact | <command or observable condition> | <least privilege required> | <none, or state why no maintenance window is needed> | <what means do not proceed> | <how to return to the prior state> |
+| [MEDIUM RISK] | Reversible state changes that can interrupt management, networking, or workload placement | <command or observable condition> | <least privilege required> | <approval or maintenance window needed before action> | <what means do not proceed> | <how to return to the prior state> |
+| [HIGH RISK] | Firmware, reboot, destructive cleanup, storage, quorum, or workload-impacting actions | <command or observable condition> | <least privilege required> | <approved maintenance window and workload-owner notification> | <what means do not proceed> | <how to return to the prior state or escalate> |
+```
+
+---
+
+## Prerequisites and stop gates
+
+Use this table before any action pattern. The reader should know what to check, what success looks like, and when to stop.
+
+```markdown
+## Prerequisites
+
+| Requirement | How to confirm | Expected result | Stop if not met |
+| --- | --- | --- | --- |
+| Administrative PowerShell on an Azure Local node | `whoami /groups` | The required admin group is present | Escalate to a cluster administrator |
+| Maintenance window, if workloads may move or restart | <change record, approval, or customer confirmation> | The window covers the expected impact | Schedule the change first |
+| Current state captured | Save the output from the pre-check command | Output is attached to the case or pull request (PR) | Do not run the action until current state is recorded |
+```
+
+---
+
+## Author assembly checklist
+
+Use this checklist before copying snippets into an article. It keeps article authors from guessing which sections are required for each document type.
+
+| Document type | Required snippet blocks | Optional snippet blocks | Fast path placement |
+| --- | --- | --- | --- |
+| Troubleshooting guide | Metadata marker, applicable products, risk and safety, prerequisites, where this appears, complete action pattern, expected output, verify the fix, evidence bundle | Owner handoff, workload impact, OEM boundary, multi-node rollout | Put the fastest safe diagnosis and stop gate before deeper explanation |
+| How-to guide | Metadata marker, applicable products, prerequisites, risk and safety, complete action pattern, expected output, rollback, verification | Workload impact, rollout table, customer summary | Put the top three actions before background information |
+| Reference article | Metadata marker, applicable products, supported versions, defaults, constraints, expected output, validation command | Glossary, owner handoff, evidence bundle | Put required settings and supported versions before examples |
+| Overview | Metadata marker, applicable products, owner and impact summary, customer-facing summary, scope, next action | Glossary, handoff table | Put the reader decision and owner first |
+| Deep dive | Metadata marker, applicable products, glossary, evidence, validation command, operational boundaries | Workload impact, OEM boundary, rollout table | Put the mechanism summary before detailed internals |
+
+Use this fast-path table when the reader needs the shortest safe path before the full article.
+
+| Step | Prompt to fill | Stop gate | Revalidation |
+| --- | --- | --- | --- |
+| 1. Confirm scope | Product, supported version, node or site, and owner | Stop if the product or version is out of scope | Record the scope in the evidence bundle |
+| 2. Run read-only detection | The command or portal check that proves the issue exists | Stop if the output is healthy, empty when empty is healthy, or inconclusive | Save the exact output and timestamp |
+| 3. Choose the action | The risk-labeled action, privilege, workload gate, maintenance window, rollback, and escalation owner | Stop if rollback is unavailable, privilege is missing, workload approval is missing, or maintenance gating is unresolved | Run the verification command and record pass or fail |
+
+---
+
+## Complete action pattern
+
+Every generated action pattern should prompt for pre-check, action, expected result or output, stop condition, rollback, and verification.
+
+````markdown
+## Action: <short action name>
+
+> [!WARNING]
+> [<READ-ONLY|LOW RISK|MEDIUM RISK|HIGH RISK>] <Explain the impact in one sentence. Use READ-ONLY only when no state changes.>
+
+### Privilege and workload gate
+
+| Gate | Required value |
+| --- | --- |
+| Required privilege | <least privilege role or local group> |
+| Workload impact | <none, live migration, pause, restart, drain, or downtime> |
+| Maintenance or approval gate | <not required, approval required, or approved maintenance window> |
+| Escalation owner | <role or team to contact if a stop condition is hit> |
+
+### Pre-check
+
+Run this before changing state.
+
+```powershell
+ # Read the current state.
+<read-only command>
+```
+
+Expected output:
+
+```console
+<Field>    <Expected healthy or actionable value>
+```
+
+Stop if: <condition that means the action is unsafe, out of scope, or already complete>.
+
+### Action
+
+Run this only after the pre-check matches the expected state.
+
+```powershell
+ # Change only the documented state.
+<state-changing command>
+```
+
+Expected result:
+
+```console
+<success message, status field, or changed value>
+```
+
+### Rollback
+
+Use this if the action fails, the expected result does not appear, or the customer requests backout.
+
+```powershell
+ # Restore the prior state captured in the pre-check.
+<rollback command>
+```
+
+Expected rollback output:
+
+```console
+<status field, restored value, or success message>
+```
+
+Rollback verification:
+
+```powershell
+<read-only rollback verification command>
+```
+
+Resume only if: <rollback verification output confirms the prior state is restored>.
+
+### Verification
+
+Re-run the detection command and confirm the healthy output.
+
+```powershell
+<read-only verification command>
+```
+
+Pass criteria: <exact field or result that means the issue is resolved>.
+Fail criteria: <exact field or result that means escalation is required>.
+Escalation: <role or team to contact, with the evidence bundle attached>.
+````
+
+---
+
+## Expected output and validation
+
+Show the reader what success, failure, empty output, and inconclusive output mean for the specific check.
+
+````markdown
+## Expected output
+
+Healthy output:
+
+```console
+Name                         Status     Detail
+<check-or-resource-name>     Success    <healthy detail text>
+```
+
+Unhealthy output:
+
+```console
+Name                         Status     Detail
+<check-or-resource-name>     Failure    <actionable failure detail text>
+```
+
+No output means: <healthy, unhealthy, inconclusive, or not applicable for this check>.
+
+## Verify the fix
+
+1. Re-run the same detection command used in the diagnosis section.
+2. Confirm the result matches the healthy output above.
+3. If the issue was discovered during pre-update validation, re-run the documented health check, for example `Invoke-SolutionUpdatePrecheck -SystemHealth`, then confirm `Get-SolutionUpdateEnvironment` shows `HealthState` as `Success`.
+4. If validation still fails, collect the evidence listed in the detection surfaces table and escalate with the before and after output.
+````
+
+---
+
+## Where this appears
+
+Use this table to document administrator detection surfaces. Use only these states: `shown`, `not-evident`, and `absent`. `shown` means the surface displays the issue. `not-evident` means the surface was actually checked with a named command, blade, log, time window, timestamp, or freshness proof and did not display the issue. `absent` means the surface has not been characterized yet, so treat it as a draft work item rather than a publishable final state for troubleshooting content.
+
+```markdown
+## Where this appears
+
+| Surface | State: shown, not-evident, or absent | What to look for | Evidence and freshness required for shown or not-evident |
+| --- | --- | --- | --- |
+| PowerShell on an Azure Local node | <shown/not-evident/absent> | <cmdlet and key field> | <command, output, node scope, and timestamp> |
+| Azure portal | <shown/not-evident/absent> | <blade, health state, or update precheck result> | <blade name, status text, and screenshot or timestamp> |
+| Windows event logs | <shown/not-evident/absent> | <log, provider, Event ID, and message fragment> | <log query, time window, latest event time, and result count> |
+| Cluster logs, `Get-ClusterLog` | <shown/not-evident/absent> | <event or state, or state that the issue is not logged there> | <cluster log command, time window, and result count> |
+| Failover Cluster Manager | <shown/not-evident/absent> | <role, resource, node state, or why the surface is not-evident> | <view checked and timestamp> |
+| Windows Admin Center, standalone | <shown/not-evident/absent> | <view or why the surface is not-evident> | <view checked and timestamp> |
+| Windows Admin Center in Azure portal | <shown/not-evident/absent> | <view or why the surface is not-evident> | <view checked and timestamp> |
+| Component or tool log files | <shown/not-evident/absent> | <path to the tool log or report file> | <path, file modified time, excerpt, and result count> |
+```
+
+---
+
+## Test automation metadata
+
+Use this block when a troubleshooting guide (TSG) has been linted or live-tested by TSG-FORGE. Keep customer identifiers, cluster names, IP addresses, subscription IDs, and tenant-specific values out of public files.
+
+````markdown
+## Test automation metadata
+
+```json
+{
+  "schema": "azure-local-supportability/tsg-metadata/v1",
+  "document_type": "troubleshoot",
+  "products": ["Azure Local"],
+  "detector": {"type":"none","signal":null},
+  "validation": {
+    "fidelity_level": "L0",
+    "technical_grade": null,
+    "reproduction_substrate": "none",
+    "automation_status": "not-assessed",
+    "last_validated": null,
+    "spec_ref": ""
+  }
+}
+```
+````
+
+Use these compact rubrics when filling the schema fields and companion evidence. Record execution surface, loop steps, report links, and evidence in the article body, PR description, or companion spec rather than adding out-of-schema fields to the marker.
+
+| Field | Values | Meaning |
+| --- | --- | --- |
+| `document_type` | deep-dive, how-to, overview, reference, troubleshoot | Use the token that matches the article template filename. Do not use display names such as Deep Dive or How To inside the JSON marker. |
+| `detector.type` | command, control-plane, envchecker, eventlog, feature, manual, none, portal, registry, service, telemetry | Use `none` only when the article has no detector. When using `none`, `detector.signal` must be JSON `null`. |
+| `fidelity_level` | L0, L1, L2, L3, L4 | L0 means static lint or persona review only. L1 means read-only diagnostics were run. L2 means a faithful detector, proxy, or synthetic input was tested. L3 means the real mechanism was tested on a scratch or isolated object. L4 means the full genuine inject, detect, mitigate, and revalidate loop passed. |
+| `technical_grade` | null, A, B, C, F | This is the authoritative technical grade field. Use JSON `null` until TSG-FORGE produces A, B, C, or F with report or spec evidence. |
+| `automation_status` | not-assessed, scaffold, ready, proven, blocked, manual | Test readiness. Use not-assessed before review, scaffold when planned but not implemented, ready when automation exists but is not proven, proven when it has passed with evidence, blocked when automation cannot proceed yet, and manual when a human must verify. |
+| `execution_surface` | on-device, mixed, cloud-diagnostic, cloud-control, thin | Runtime location. This is separate from `automation_status`: on-device runs on a node, mixed uses node plus cloud checks, cloud-diagnostic depends on cloud telemetry, cloud-control changes connected Azure state, and thin has no executable diagnostic or action. |
+
+```markdown
+## Validation evidence
+
+| Field | Value |
+| --- | --- |
+| Execution surface | <on-device, mixed, cloud-diagnostic, cloud-control, or thin> |
+| TSG-FORGE report | <report path or PR link> |
+| Companion spec | <spec path or empty if not applicable> |
+| Loop evidence | <baseline, inject, detect, mitigate, and revalidate results, or not applicable> |
+| Freshness | <validation date, report timestamp, or reason freshness is not applicable> |
+```
+
+---
+
+## Owner, impact, and handoff snippets
+
+Use this compact set when the article needs a decision owner, customer context, workload impact, or a handoff boundary.
+
+| Snippet | Copy-ready prompt |
+| --- | --- |
+| Owner and impact summary | State the business impact, technical owner, customer-visible impact, expected duration, downtime risk, and escalation path in one paragraph. |
+| Customer-facing summary | In plain language, state the current state, who owns the next action, what will happen next, expected timing, and what the customer can safely do while waiting. |
+| Owner handoff | Record the primary owner, secondary owner, evidence already collected, evidence still needed, and the condition that transfers ownership. |
+| Workload impact | State whether VMs move, live migrate, pause, restart, drain, or experience downtime. Name the required approval and maintenance window. |
+| OEM boundary | State the hardware evidence, firmware or driver target, owner, and the signal that this is not an OEM action. |
+| Accessibility context | Explain why the step matters, who it helps, what risk it avoids, and the safe next action for a reader who cannot perform the change. |
+
+```markdown
+## Owner, impact, and handoff
+
+| Field | Value |
+| --- | --- |
+| Business or customer impact | <plain-language impact> |
+| Primary owner | <customer IT, partner or system integrator (SI), original equipment manufacturer (OEM), Microsoft Customer Service and Support (CSS), or product group> |
+| Secondary owner or handoff target | <team or role> |
+| Expected duration | <time estimate or not known> |
+| Downtime or workload risk | <none, live migration, reboot, drain, or outage> |
+| Approval required | <none, change record, maintenance window, or customer approval> |
+| Evidence collected | <commands, logs, screenshots, timestamps, and validation output> |
+| Escalation path | <who to contact and what evidence to include> |
+```
+
+---
+
+## Worked safe-action and rollout snippets
+
+Use a filled safe-action example when readers may not know how to replace placeholders. This example is read-only, so rollback records that no state changed.
+
+### Filled safe-action example
+
+| Contract field | Filled example |
+| --- | --- |
+| Label | [READ-ONLY] |
+| Required privilege | User rights sufficient to run read-only PowerShell DNS queries on the node. |
+| Workload or maintenance gate | No workload impact and no maintenance window required because this is read-only. |
+| Pre-check | Confirm PowerShell can resolve a public Microsoft endpoint from the node. |
+| Action | Run `Resolve-DnsName -Name "management.azure.com" -ErrorAction Stop`. |
+| Expected output | Output includes `Name` set to `management.azure.com` and at least one returned record. |
+| Stop condition | Stop if the command returns an error or no record. Do not continue to a DNS mitigation until the failing output is saved. |
+| Rollback | No rollback is required because this example is read-only and changes no state. Expected rollback output is not applicable. |
+| Rollback verification | Not applicable because no state changed. |
+| Verification | Re-run the same command after any DNS remediation and compare the before and after output. |
+| Escalation | Escalate to the network or DNS owner with the before and after output if verification still fails. |
+
+```powershell
+$ErrorActionPreference = "Stop"
+Resolve-DnsName -Name "management.azure.com" -ErrorAction Stop
+```
+
+```console
+Name                                           Type   TTL   Section    IPAddress
+management.azure.com                          A      60    Answer     20.50.2.1
+```
+
+Use this rollout table when a guide applies to more than one node, cluster, or site.
+
+```markdown
+## Rollout plan
+
+| Target | Run order | Parallelism rule | Pre-check evidence | Result | Validation evidence |
+| --- | --- | --- | --- | --- | --- |
+| <site or node 1> | 1 | <serial or parallel with safe peer set> | <before output and timestamp> | <pass, fail, or skipped> | <after output and timestamp> |
+| <site or node 2> | 2 | <serial or parallel with safe peer set> | <before output and timestamp> | <pass, fail, or skipped> | <after output and timestamp> |
+```
+
+---
+
+## Evidence, glossary, and validation snippets
+
+Use this section to make escalation and validation repeatable.
+
+### Evidence bundle
+
+```markdown
+## Evidence bundle for escalation
+
+| Evidence | Required detail |
+| --- | --- |
+| Detection command output | Exact command, output, node name redacted if needed, and timestamp |
+| Expected output comparison | Healthy output, observed output, and why the result is pass, fail, empty, or inconclusive |
+| Windows event logs | Log name, provider, Event ID, message fragment, and timestamp |
+| Component or tool logs | File path, relevant excerpt, and collection time |
+| Azure portal or Windows Admin Center screenshot | Blade name, status text, timestamp, and any redacted identifiers |
+| Rollback or mitigation result | Command, expected result, actual result, and timestamp |
+| Final verification | Revalidation command, output, pass or fail result, and next owner |
+```
+
+### Glossary
+
+| Term | Meaning |
+| --- | --- |
+| TSG | Troubleshooting guide. |
+| TSG-FORGE | The template and troubleshooting-guide validation harness used to lint, grade, and, when applicable, live-test a guide. |
+| Detector | The source that proves the issue exists, such as envchecker, eventlog, command, service, feature, registry, telemetry, manual, or control-plane. |
+| envchecker | An Environment Validator detector that reads Azure Local validator results. |
+| Fidelity level | How deeply the TSG was tested, from L0 static review to L4 full inject, detect, mitigate, and revalidate. See the Test automation metadata rubric above for the full L0 to L4 definitions. |
+| Technical grade | The authoritative `validation.technical_grade` value from TSG-FORGE: JSON `null` before grading, then A, B, C, or F with report or spec evidence. |
+| Automation status | The readiness of test automation, such as not-assessed, scaffold, ready, proven, blocked, or manual. This is not the same as execution surface. |
+| Execution surface | Where the diagnostic or action runs, such as on-device, mixed, cloud-diagnostic, cloud-control, or thin. This is not the same as automation status. |
+| Reproduction substrate | The environment where the issue can be reproduced, such as vm, hardware, either, or none. |
+| VM | Virtual machine. |
+| OEM | Original equipment manufacturer. |
+| SI | System integrator. |
+| CSS | Microsoft Customer Service and Support. |
+| BMC | Baseboard management controller. |
+| Event ID | A numeric Windows event identifier that must be paired with its log name and provider. |
+| Stop condition | A specific result that means the reader must not continue with the action. |
+| Not evident | The surface was checked or considered, and the issue is not visible there. |
+| Absent | The surface has not been characterized yet. Treat this as a draft work item for troubleshooting content. |
+
+### Validation command
+
+Record the command, grade, report path, and any deterministic review output before publishing.
+
+```console
+python3 <path-to-tsg-forge>/harness.py --lint --tsg <article-file>
+python3 <path-to-tsg-pr-review>/scripts/lint_tsg.py <article-file>
+```
+
+```markdown
+## Validation record
+
+| Check | Command | Result | Report path or output |
+| --- | --- | --- | --- |
+| TSG-FORGE lint | `python3 <path-to-tsg-forge>/harness.py --lint --tsg <article-file>` | <A, B, F, or not run> | <report path> |
+| Deterministic PR lint | `python3 <path-to-tsg-pr-review>/scripts/lint_tsg.py <article-file>` | <zero findings, or finding count> | <output path or pasted JSON> |
+```
+
+---
+
+## Alert and emphasis boxes
+
+Prefer standard Markdown admonitions for public TSGs. Use styled HTML only when Markdown cannot express the required layout.
+
+### Important information
 
 ```markdown
 > [!IMPORTANT]
 > This is critical information that readers must understand before proceeding.
 ```
 
-### Warning Messages
+### Warning messages
 
 ```markdown
 > [!WARNING]
-> This action could cause system downtime or data loss. Proceed with caution.
+> [MEDIUM RISK] This action could cause system downtime or data loss. Complete the pre-check, rollback, and verification steps before proceeding.
 ```
 
-### Helpful Notes
+### Helpful notes
 
 ```markdown
 > [!NOTE]
 > This provides additional context or clarification for the reader.
 ```
 
-### Helpful Tips
+### Helpful tips
 
 ```markdown
 > [!TIP]
 > This offers a useful suggestion or best practice.
 ```
 
-### Caution Alerts
+### Caution alerts
 
 ```markdown
 > [!CAUTION]
@@ -43,28 +492,28 @@ This document provides copy-paste snippets for common formatting elements used i
 
 ---
 
-## Mermaid Markdown Diagrams and Flow Charts
+## Mermaid Markdown diagrams and flow charts
 
-For consistency and readability in Light and Dark mode, use the following flowchart template.
+For consistency and readability in light and dark mode, use the following flowchart template.
 
 ```mermaid
 flowchart TD
-    %% Basic nodes with different shapes/text formatting
+    %% Basic nodes with different shapes and text formatting
     Start["Starting Node"]
     Decision{"Decision Node"}
     Action["Action Node"]
     Warning["Warning Node"]
 
     %% Different types of arrows and labels
-    Start --> Decision                    %% Simple arrow
-    Decision -- "Yes" --> Action         %% Arrow with text
-    Decision --"No"--> Warning           %% Arrow with text (no spaces)
-    Action ==> Warning                    %% Thick arrow
-    Warning -.-> Start                    %% Dotted arrow
-    
+    Start --> Decision
+    Decision -- "Yes" --> Action
+    Decision -- "No" --> Warning
+    Action ==> Warning
+    Warning -.-> Start
+
     %% Subgraph example
     subgraph ProcessGroup
-        direction TB  %% Top to Bottom direction
+        direction TB
         Step1["First Step"]
         Step2["Second Step"]
         Step3["Third Step"]
@@ -91,57 +540,59 @@ flowchart TD
 
 ---
 
-## Advanced HTML Callout Boxes
+## Optional HTML callout boxes
 
-### Basic Note Box
+Use these only when standard Markdown admonitions are not enough. Keep labels as text and avoid icon-only meaning.
+
+### Basic note box
 
 <div style="border-left: 4px solid #0366d6; padding: 15px; margin: 20px 0; background: rgba(3, 102, 214, 0.1); border-radius: 6px;">
-  <strong>📘 Note:</strong> This is a general note for additional information or clarification on a topic.
+  <strong>Note:</strong> This is a general note for additional information or clarification on a topic.
 </div>
 
 ```html
 <div
   style="border-left: 4px solid #0366d6; padding: 15px; margin: 20px 0; background: rgba(3, 102, 214, 0.1); border-radius: 6px;"
 >
-  <strong>📘 Note:</strong> This is a general note for additional information or
+  <strong>Note:</strong> This is a general note for additional information or
   clarification on a topic.
 </div>
 ```
 
-### Warning/Info Callout Box
+### Waiting time callout box
 
 <div style="border-left: 4px solid #f9c74f; padding: 15px; margin: 20px 0; background: rgba(249, 199, 79, 0.1); border-radius: 6px;">
-  <strong>⏳ Waiting Time:</strong> Allow 10–15 minutes for logs to accumulate before proceeding with the next steps.
+  <strong>Waiting time:</strong> Allow 10 to 15 minutes for logs to accumulate before proceeding with the next steps.
 </div>
 
 ```html
 <div
   style="border-left: 4px solid #f9c74f; padding: 15px; margin: 20px 0; background: rgba(249, 199, 79, 0.1); border-radius: 6px;"
 >
-  <strong>⏳ Waiting Time:</strong> Allow 10–15 minutes for logs to accumulate
+  <strong>Waiting time:</strong> Allow 10 to 15 minutes for logs to accumulate
   before proceeding with the next steps.
 </div>
 ```
 
-### Important Info Box
+### Important information box
 
 <div style="border-left: 4px solid #28a745; padding: 15px; margin: 20px 0; background: rgba(40, 167, 69, 0.1); border-radius: 6px;">
-  <strong>⚠️ Important:</strong> Please ensure you follow the recommended steps carefully to avoid unintended issues.
+  <strong>Important:</strong> Follow the recommended steps carefully to avoid unintended issues.
 </div>
 
 ```html
 <div
   style="border-left: 4px solid #28a745; padding: 15px; margin: 20px 0; background: rgba(40, 167, 69, 0.1); border-radius: 6px;"
 >
-  <strong>⚠️ Important:</strong> Please ensure you follow the recommended steps
-  carefully to avoid unintended issues.
+  <strong>Important:</strong> Follow the recommended steps carefully to avoid
+  unintended issues.
 </div>
 ```
 
-### Common Causes Box
+### Common causes box
 
 <div style="border-left: 4px solid #dc3545; padding: 15px; margin: 20px 0; background: rgba(220, 53, 69, 0.1); border-radius: 6px;">
-  <h4 style="margin-top: 0; color: #dc3545;">Common Causes</h4>
+  <h4 style="margin-top: 0; color: #dc3545;">Common causes</h4>
   <ul>
     <li>Potential cause one</li>
     <li>Potential cause two</li>
@@ -153,7 +604,7 @@ flowchart TD
 <div
   style="border-left: 4px solid #dc3545; padding: 15px; margin: 20px 0; background: rgba(220, 53, 69, 0.1); border-radius: 6px;"
 >
-  <h4 style="margin-top: 0; color: #dc3545;">Common Causes</h4>
+  <h4 style="margin-top: 0; color: #dc3545;">Common causes</h4>
   <ul>
     <li>Potential cause one</li>
     <li>Potential cause two</li>
@@ -162,39 +613,39 @@ flowchart TD
 </div>
 ```
 
-### Advanced Tips Box
+### Advanced tip box
 
 <div style="border-left: 4px solid #6f42c1; padding: 12px; margin: 20px 0; background: rgba(111, 66, 193, 0.1); border-radius: 6px; font-size: 0.9em;">
-  <strong>💡 Tip:</strong> This box can provide advanced tips or optional steps for users seeking deeper insights.
+  <strong>Tip:</strong> This box can provide advanced tips or optional steps for users seeking deeper insights.
 </div>
 
 ```html
 <div
   style="border-left: 4px solid #6f42c1; padding: 12px; margin: 20px 0; background: rgba(111, 66, 193, 0.1); border-radius: 6px; font-size: 0.9em;"
 >
-  <strong>💡 Tip:</strong> This box can provide advanced tips or optional steps
+  <strong>Tip:</strong> This box can provide advanced tips or optional steps
   for users seeking deeper insights.
 </div>
 ```
 
 ---
 
-## Code Blocks
+## Code blocks
 
-### PowerShell Commands
+### PowerShell commands
 
 ````markdown
 ```powershell
-# Description of what this command does
-Get-Process | Where-Object {$_.ProcessName -eq "example"}
+ # Description of what this command does
+Get-Process | Where-Object { $_.ProcessName -eq "example" }
 ```
 ````
 
-### Console/Terminal Output
+### Console or terminal output
 
 ````markdown
 ```console
-# Network configuration example
+Network configuration example
 interface Ethernet1/1
   description Azure Local Node Connection
   switchport mode trunk
@@ -202,7 +653,7 @@ interface Ethernet1/1
 ```
 ````
 
-### JSON Configuration
+### JSON configuration
 
 ````markdown
 ```json
@@ -216,12 +667,14 @@ interface Ethernet1/1
 ```
 ````
 
-### Generic Code Block
+### Plain text block
+
+Use a language identifier whenever the content is a command, output, JSON, XML, YAML, log, or configuration. Use `text` only for plain text that has no better language.
 
 ````markdown
-```
+```text
 Generic text or configuration content
-that doesn't fit a specific language
+that does not fit a specific language
 ```
 ````
 
@@ -229,26 +682,26 @@ that doesn't fit a specific language
 
 ## Tables
 
-### Basic Specifications Table
+### Basic specifications table
 
 ```markdown
-| Requirement   | Specification | Notes                    |
-| ------------- | ------------- | ------------------------ |
-| **Component** | Details here  | Additional context       |
-| **Setting**   | Value here    | Important considerations |
+| Requirement | Specification | Notes |
+| --- | --- | --- |
+| **Component** | Details here | Additional context |
+| **Setting** | Value here | Important considerations |
 ```
 
-### Comparison Table
+### Comparison table
 
 ```markdown
-| Feature         | Option 1          | Option 2   | Option 3    |
-| --------------- | ----------------- | ---------- | ----------- |
-| **Performance** | High              | Medium     | Low         |
-| **Complexity**  | Low               | Medium     | High        |
-| **Use Case**    | Small deployments | Enterprise | Specialized |
+| Feature | Option 1 | Option 2 | Option 3 |
+| --- | --- | --- | --- |
+| **Performance** | High | Medium | Low |
+| **Complexity** | Low | Medium | High |
+| **Use Case** | Small deployments | Enterprise | Specialized |
 ```
 
-### Metadata Table (for TSG documents)
+### Metadata table for TSG documents
 
 <table border="1" cellpadding="6" cellspacing="0" style="border-collapse:collapse; margin-bottom:1em;">
   <tr>
@@ -276,14 +729,14 @@ that doesn't fit a specific language
 
 ---
 
-## Emojis
+## Status labels
+
+Use text labels. If a visual indicator is added later, the text label must remain.
 
 ```markdown
-- ✅ Recommended approach
-- ⚠️ Proceed with caution
-- 🚫 Not recommended
-- 🔧 Requires configuration
-- 📋 Note
+- Recommended: Use this approach.
+- Warning: Proceed with caution.
+- Not recommended: Avoid this approach.
+- Requires configuration: Complete the prerequisite configuration first.
+- Note: Additional context follows.
 ```
-
----

--- a/TSG/Templates/Overview-Template.md
+++ b/TSG/Templates/Overview-Template.md
@@ -1,154 +1,249 @@
-<!--
-Overview Template
-- Overview documents give architectural guidance and conceptual understanding
-- Replace all {placeholders} with relevant content
-- This template provides a suggested structure - adapt it to make sense for your specific content
-    - The goal is clarity and usability for the reader
-
-Styling
-- Images should be placed in the `./images` folder and referenced
-- Any code block or JSON should be wrapped in triple backticks (```) with language identifier
-- References to Azure Local public documentation should always direct to the latest version
-- Use tables for comparisons and specifications
-- Use diagrams and visuals to illustrate concepts
-
-You can use this regex to find placeholders that need to be replaced (search by Regex in your editor): \{([^}]+)\}
+<!-- tsg-metadata
+{
+  "schema": "azure-local-supportability/tsg-metadata/v1",
+  "document_type": "overview",
+  "products": ["replace-me"],
+  "detector": {
+    "type": "none",
+    "signal": null
+  },
+  "validation": {
+    "fidelity_level": "L0",
+    "technical_grade": null,
+    "reproduction_substrate": "none",
+    "automation_status": "not-assessed",
+    "last_validated": null,
+    "spec_ref": ""
+  }
+}
 -->
 
 # {Title}
 
-_{Brief subtitle or description that summarizes the document's purpose and scope}_
+_{Brief subtitle that summarizes the document purpose, scope, and reader decision}_
 
----
+> [!IMPORTANT]
+> This is an overview template. Use it for architectural guidance, conceptual orientation, and decision support. Do not turn an overview into a troubleshooting guide. If the article primarily diagnoses or fixes a failure, use the Troubleshoot template instead.
+
+## At-a-glance routing card
+
+Complete this card before writing the body. It gives skimmers, account teams, and urgent field readers the first-screen answer they need.
+
+| Routing field | Author prompt |
+| ------------- | ------------- |
+| **Plain-language summary** | {In the first 100 words, explain the topic without assuming Azure Local expertise. Expand acronyms on first use. Examples that often need expansion: Azure Arc, Arc Resource Bridge, Storage Spaces Direct, Windows Admin Center, original equipment manufacturer (OEM), Microsoft Customer Service and Support (CSS), and systems integrator (SI).} |
+| **Use this overview when** | {State the reader situation where conceptual orientation or decision support is the right article type.} |
+| **Do not use this overview when** | {State when the reader should use a Troubleshoot, How-To, Reference, or Deep Dive article instead. If the reader is blocked by an active failure, point them to the appropriate public troubleshooting article when one exists.} |
+| **Customer or workload impact** | {Summarize whether the topic can affect customers, virtual machine (VM) availability, deployment timelines, operations, security posture, or has no expected customer impact.} |
+| **Downtime or change risk** | {State whether the overview implies no change, planning-only change, or a potential state-changing action that must use [LOW RISK], [MEDIUM RISK], or [HIGH RISK] labeling in the action pattern.} |
+| **Expected reader decision** | {Name the decision, understanding, or next conversation the reader should be ready for after reading.} |
+| **Accountable owner and escalation lane** | {Name the owning role and the handoff path. Examples: customer IT, Microsoft CSS, product engineering, partner or SI, or OEM vendor.} |
+| **Next action** | {Link or name the next public Microsoft article, decision review, or owner follow-up.} |
 
 ## Table of Contents
 
-- [1. Introduction](#1-introduction)
-- [2. {Main Topic Area}](#2-main-topic-area)
-- [3. {Secondary Topic Area}](#3-secondary-topic-area)
-- [4. Frequently Asked Questions](#4-frequently-asked-questions)
-- [5. Additional Resources](#5-additional-resources)
+- [At-a-glance routing card](#at-a-glance-routing-card)
+- [1. Purpose and audience](#1-purpose-and-audience)
+- [2. Scope and applicability](#2-scope-and-applicability)
+- [3. Architecture and key concepts](#3-architecture-and-key-concepts)
+- [4. Operational boundaries and risks](#4-operational-boundaries-and-risks)
+- [5. Claims and validation](#5-claims-and-validation)
+- [6. Frequently asked questions](#6-frequently-asked-questions)
+- [7. Additional resources](#7-additional-resources)
+- [8. Before publishing checklist](#8-before-publishing-checklist)
 
----
+## 1. Purpose and audience
 
-## 1. Introduction
+{Explain what this overview covers, why it matters, and how it fits into the broader Azure Local ecosystem.}
 
-{Introduction explaining what this overview covers, who should read it, and how it fits into the broader Azure Local ecosystem}
+| Field | Author prompt |
+| ----- | ------------- |
+| **Audience** | {Primary readers. Examples: IT leadership, Azure Local operators, deployment partners, CSS, OEM field engineers.} |
+| **Reader decision or outcome** | {State what the reader should understand or decide after reading this overview.} |
+| **Assumed knowledge** | {List the Azure Local, Windows Server, networking, storage, security, or Azure concepts the reader should already know.} |
+| **Accessibility notes** | {Define terms that may block new readers. Avoid unexplained acronyms.} |
+| **Owner or accountable team** | {Name the team or role responsible for keeping the overview current.} |
 
-This guide complements the official Azure Local documentation and provides practical guidance with focus on:
+This overview complements the official [Azure Local documentation](https://learn.microsoft.com/azure/azure-local/) and provides practical guidance with focus on:
 
 - {Key focus area 1}
 - {Key focus area 2}
 - {Key focus area 3}
 - {Key focus area 4}
 
-### Key Terminology
+## 2. Scope and applicability
 
-{Optional section - include if there are important terms that readers need to understand}
+{Define the exact product area, deployment phase, and reader scenario this overview covers.}
 
-| Term         | Definition         |
-| ------------ | ------------------ |
-| **{Term 1}** | {Clear definition} |
-| **{Term 2}** | {Clear definition} |
-| **{Term 3}** | {Clear definition} |
+| Applicability field | Required value |
+| ------------------- | -------------- |
+| **Applicable products** | {List each product explicitly. Example: Azure Local, Azure Arc, Azure Kubernetes Service on Azure Local.} |
+| **Supported versions** | {List supported Azure Local releases, OS builds, extension versions, hardware generation, or service versions. Use current public Microsoft documentation as the source.} |
+| **In scope** | {List what this overview explains.} |
+| **Out of scope and non-goals** | {List what this overview does not explain. Link to a Troubleshoot, How-To, Reference, or Deep Dive article when a different document type is better.} |
+| **Environment assumptions** | {State whether the guidance assumes connected Azure, disconnected operations, specific OEM hardware, specific network topology, or a deployed cluster.} |
+| **Rollout repeatability** | {State what changes across sites, OEMs, supported versions, deployment modes, scale units, regions, or customer environments. If nothing varies, say that explicitly.} |
+| **OEM and partner ownership boundary** | {State whether the topic is hardware-owned, firmware-owned, partner-owned, Microsoft-owned, customer-owned, or explicitly not an OEM issue.} |
+| **Handoff boundaries** | {State when the reader should hand off to customer IT, partner or SI, OEM vendor, Microsoft CSS, or product engineering.} |
 
----
+## 3. Architecture and key concepts
 
-## 2. {Main Topic Area}
+{Describe the architecture, dependencies, data flow, ownership model, or conceptual model. Keep this section explanatory rather than procedural.}
 
-{Primary content section providing architectural guidance and high-level concepts}
+### Key terminology
 
-### {Subtopic 1}
+{Include terms that readers need to understand before they act on the overview.}
 
-{Explanation of key concepts, approaches, or patterns}
+| Term | Definition |
+| ---- | ---------- |
+| **{Term 1}** | {Clear definition and why the term matters.} |
+| **{Term 2}** | {Clear definition and why the term matters.} |
+| **{Term 3}** | {Clear definition and why the term matters.} |
 
-![Diagram Description](images/{diagram-filename}.png)
+### Conceptual model
 
-### {Subtopic 2}
+{Explain the major components and how they interact.}
 
-{Additional architectural concepts or guidance}
+> [!TIP]
+> If a diagram helps, place it in the local `images` folder, use descriptive alt text, and reference only the actual file. Remove the image line if no diagram is supplied.
 
-### {Topic Comparison/Analysis}
+![{Descriptive diagram alt text}](images/{diagram-filename}.png)
 
-{Use tables to compare different approaches, patterns, or options}
+### Comparison or decision matrix
 
-| {Approach/Pattern} | {Criteria 1}  | {Criteria 2}  | {Primary Use Cases} |
-| ------------------ | ------------- | ------------- | ------------------- |
-| **{Option 1}**     | {Description} | {Description} | {When to use}       |
-| **{Option 2}**     | {Description} | {Description} | {When to use}       |
-| **{Option 3}**     | {Description} | {Description} | {When to use}       |
+{Use tables to compare options, patterns, responsibilities, or tradeoffs.}
 
----
+| Option or pattern | When to use | Benefits | Constraints | Owner |
+| ----------------- | ----------- | -------- | ----------- | ----- |
+| **{Option 1}** | {Scenario} | {Benefit} | {Constraint} | {Owner} |
+| **{Option 2}** | {Scenario} | {Benefit} | {Constraint} | {Owner} |
+| **{Option 3}** | {Scenario} | {Benefit} | {Constraint} | {Owner} |
 
-## 3. {Secondary Topic Area}
+## 4. Operational boundaries and risks
 
-### {Requirements/Considerations}
+{Use this section when overview guidance could influence operations, change planning, support routing, workload availability, security posture, or vendor ownership. If there is no operational effect, state that explicitly.}
 
-{Section covering important requirements, constraints, or considerations}
+| Boundary or risk | Author prompt |
+| ---------------- | ------------- |
+| **Safe use** | {Explain how the overview should be used without treating it as a procedure.} |
+| **Not covered here** | {State which troubleshooting, deployment, or repair actions belong in another article type.} |
+| **Workload or availability considerations** | {State whether concepts in this overview imply virtual machine (VM) downtime, maintenance windows, quorum risk (risk that the cluster loses enough voting members to stay online), network interruption, or no workload effect.} |
+| **Security posture considerations** | {State whether the topic affects identity, role-based access control (RBAC), certificates, firewall policy, secrets, or has no expected security effect.} |
+| **Risk label when actions are included** | {Use [LOW RISK], [MEDIUM RISK], or [HIGH RISK] for any example that could change state.} |
+| **Escalation or handoff** | {State when to involve CSS, product engineering, an OEM vendor, a partner or SI, or customer change-control owners.} |
 
-| Requirement         | {Details}       | Notes                |
-| ------------------- | --------------- | -------------------- |
-| **{Requirement 1}** | {Specification} | {Additional context} |
-| **{Requirement 2}** | {Specification} | {Additional context} |
+### Action pattern for any state-changing example
 
-> [!NOTE]
-> {Important note about requirements or links to official documentation}
+Overview articles should avoid step-by-step repair flows. If an example action is necessary for context, label the risk and include every field below.
 
-### {Best Practices/Recommendations}
+| Field | Required prompt |
+| ----- | --------------- |
+| **Risk label** | {Choose [LOW RISK], [MEDIUM RISK], or [HIGH RISK].} |
+| **Privilege and approval gate** | {State the minimum role, local admin right, RBAC assignment, vendor approval, or change-control approval required before the action.} |
+| **Pre-check** | {Condition that must be true before the action is safe. Include health, backup, recovery-key, and ownership checks where applicable.} |
+| **Workload or maintenance gate** | {State the required maintenance window, workload-drain state, customer approval, or confirmation that the example has no workload effect.} |
+| **Action** | {The exact action or link to the proper How-To or Troubleshoot article. Prefer a link instead of embedding a repair flow in the overview.} |
+| **Expected result or output** | {What the reader should see if the action worked.} |
+| **Stop condition and escalation target** | {When the reader must stop, who owns the escalation, and what evidence to collect before handing off.} |
+| **Rollback** | {How to return to the prior state if the action is unsuccessful or no longer needed.} |
+| **Expected rollback output** | {What the reader should see when rollback succeeds.} |
+| **Rollback verification** | {How to confirm the rollback restored the prior safe state before resuming.} |
+| **Verification** | {How to confirm the environment is healthy after the action.} |
 
-{High-level guidance and recommendations}
+## 5. Claims and validation
 
-- **{Practice 1}**: {Description and rationale}
-- **{Practice 2}**: {Description and rationale}
-- **{Practice 3}**: {Description and rationale}
+{List the claims a reader may rely on. Include a source or validation reference for each testable claim. Do not make operationally important claims without a reference.}
 
----
+| Claim | Evidence or validation reference | Applicable products or supported versions | Validation status | Last reviewed |
+| ----- | -------------------------------- | ----------------------------------------- | ----------------- | ------------- |
+| {Claim 1} | {Public Microsoft Learn link, lab validation note, source reference, or product documentation} | {Products and versions} | {Not assessed, doc-backed, lab-validated, field-validated} | {YYYY-MM-DD} |
+| {Claim 2} | {Public Microsoft Learn link, lab validation note, source reference, or product documentation} | {Products and versions} | {Not assessed, doc-backed, lab-validated, field-validated} | {YYYY-MM-DD} |
 
-## 4. Frequently Asked Questions
+### Validation vocabulary
+
+Use these terms consistently. The claim status describes evidence for one statement, the fidelity level describes how deeply the article was validated, and a technical grade belongs in a separate grade report or component index.
+
+| Vocabulary | Allowed values | Meaning |
+| ---------- | -------------- | ------- |
+| **Claim validation status** | `Not assessed`, `doc-backed`, `lab-validated`, `field-validated` | `Not assessed` means no evidence yet. `doc-backed` means a public Microsoft source supports the claim. `lab-validated` means the claim was tested in a lab for the stated products and versions. `field-validated` means support or deployment evidence confirms the claim for the stated scope. |
+| **Fidelity level** | `L0`, `L1`, `L2`, `L3`, `L4` | `L0` is static review only. `L1` validates read-only diagnostics. `L2` validates a safe proxy or synthetic signal. `L3` validates a scratch-object failure and fix. `L4` validates a full inject, detect, mitigate, and revalidate loop. |
+| **Automation status** | `not-assessed`, `scaffold`, `ready`, `proven`, `blocked`, `manual` | `not-assessed` means no automation review. `scaffold` means metadata exists but automation is incomplete. `ready` means the automation path is designed but not proven. `proven` means automation was validated. `blocked` means automation cannot proceed until a stated dependency is resolved. `manual` means the article intentionally requires human execution or review. |
+| **Execution surface** | `on-device`, `mixed`, `cloud-diagnostic`, `cloud-control`, `thin` | Describes where diagnostics or actions run. Keep this distinct from `automation_status`, which describes readiness rather than location. |
+| **Admin surface state** | `shown`, `not-evident`, `absent` | Use only when characterizing admin visibility. `shown` means the surface carries evidence. `not-evident` means checked and not visible there. `absent` means uncharacterized and not publish-ready. |
+| **Technical grade** | JSON `null`, `A`, `B`, `C`, or `F` | Use `validation.technical_grade` as the authoritative grade field. Keep it as JSON `null` until TSG-FORGE produces `A`, `B`, `C`, or `F`, then cite the report or spec evidence that produced the grade. |
+
+### Future automation metadata
+
+Keep the metadata marker at the top of this file. When creating a real article, update the marker before publication and validate it against the [TSG metadata schema](../Templates/tsg-metadata.schema.json). This schema link is correct for an article copied to a component root such as `TSG/<Component>/`; for each deeper topic folder, add one `../` segment, for example `../../Templates/tsg-metadata.schema.json` from `TSG/<Component>/<Topic>/`.
+
+| Metadata field | Author prompt |
+| -------------- | ------------- |
+| **document_type** | Keep `overview` for this template. |
+| **products** | Replace `replace-me` with explicit product names. |
+| **detector.type and detector.signal** | Keep `type` as `none` and `signal` as JSON `null` for purely conceptual content. If the article gains a detection signal, set both fields together, reassess whether it is still an overview, and use only schema detector types. |
+| **validation.fidelity_level** | Use `L0` unless this overview has been validated by a stronger documented process. See the fidelity rubric in this section. |
+| **validation.technical_grade** | Keep JSON `null` until TSG-FORGE produces `A`, `B`, `C`, or `F`. This is the authoritative technical grade for component indexes and validation reports. |
+| **validation.reproduction_substrate** | Use `none` for a conceptual overview unless a validation companion proves a `vm`, `hardware`, or `either` substrate path. |
+| **validation.automation_status** | Use `not-assessed` until a TSG-FORGE or converter review assesses automation readiness. Allowed values are `not-assessed`, `scaffold`, `ready`, `proven`, `blocked`, and `manual`. |
+| **validation.last_validated** | Keep JSON `null` until a dated validation event exists, then use an ISO date such as `YYYY-MM-DD`. |
+| **validation.spec_ref** | Link a public or repository-local validation companion only when one exists and is appropriate for public use. |
+
+## 6. Frequently asked questions
 
 ### Q: {Common question about the topic}?
 
-**A:**  
-{Comprehensive answer that provides clear guidance and context}
+**A:** {Clear answer with practical guidance and context. State assumptions and link to official public Microsoft documentation when possible.}
 
 ### Q: {Another frequently asked question}?
 
-**A:**
-{Clear answer with practical guidance}
+**A:** {Clear answer. If the answer depends on product, version, hardware, or deployment phase, say so explicitly.}
 
-**{Scenario/Option 1}:**
+**{Scenario or option 1}:**
 
 - {Specific guidance for this scenario}
-- {Key considerations}
+- {Key considerations and boundaries}
 
-**{Scenario/Option 2}:**
+**{Scenario or option 2}:**
 
 - {Alternative guidance}
 - {When this applies}
 
-## 5. Additional Resources
+## 7. Additional resources
 
-For comprehensive {topic area} guidance, refer to these official Microsoft documentation resources:
+Use public Microsoft links only. Prefer links that do not pin a release view unless the article is explicitly version-specific.
 
-### Official Documentation
+### Official documentation
 
-- **[{Official Doc 1}](link)**  
-  {Brief description of what this covers}
+- **[Azure Local documentation](https://learn.microsoft.com/azure/azure-local/)**
+  {Brief description of how this source supports the overview.}
 
-- **[{Official Doc 2}](link)**  
-  {Brief description of what this covers}
+- **[{Official Microsoft Learn doc 2}]({Public Microsoft Learn URL})**
+  {Brief description of what this covers.}
 
-- **[{Official Doc 3}](link)**  
-  {Brief description of what this covers}
+- **[{Official Microsoft Learn doc 3}]({Public Microsoft Learn URL})**
+  {Brief description of what this covers.}
 
-### Related Documents
+### Related public Microsoft documents
 
-- **[{Related Doc 1}](link)** - {Brief description}
-- **[{Related Doc 2}](link)** - {Brief description}
+- **[{Related public Microsoft document 1}]({Public Microsoft Learn URL})**: {Brief description}
+- **[{Related public Microsoft document 2}]({Public Microsoft Learn URL})**: {Brief description}
 
-### Tools and Utilities
+### Tools and utilities
 
-- **[{Tool 1}](link)** - {Description of tool and its purpose}
-- **[{Tool 2}](link)** - {Description of tool and its purpose}
+- **[{Public Microsoft tool 1}]({Public Microsoft URL})**: {Description of the tool and its purpose}
+- **[{Public Microsoft tool 2}]({Public Microsoft URL})**: {Description of the tool and its purpose}
 
----
+## 8. Before publishing checklist
+
+Use this checklist before opening a pull request. It prevents the reusable template prompts from leaking into a published overview.
+
+| Check | Required result |
+| ----- | --------------- |
+| **Placeholder sweep** | {Search for unresolved brace prompts such as `{Title}` and replace or remove every one.} |
+| **Diagram cleanup** | {Remove the sample diagram line unless a real image exists in the local `images` folder with useful alt text.} |
+| **Metadata marker** | {Keep exactly one valid `<!-- tsg-metadata` marker, replace `products`: [`replace-me`] before publication, and keep `detector.signal` as JSON `null` when `detector.type` is `none`.} |
+| **Plain-language opening** | {Confirm the first 100 words define the topic, expand acronyms, and state why the reader should care.} |
+| **Public-link hygiene** | {Use public Microsoft links only. Remove internal work-item, wiki, Kusto, or engineering links from the public article.} |
+| **Applicability** | {Confirm applicable products, supported versions, environment assumptions, rollout repeatability, and OEM or partner boundaries are explicit.} |
+| **Claims** | {Confirm every testable or operationally important claim has an evidence or validation reference.} |
+| **Actions, if any** | {Confirm any state-changing example has risk, privilege, workload or maintenance gate, pre-check, action, expected output, stop condition and escalation target, rollback, expected rollback output, rollback verification, and final verification.} |

--- a/TSG/Templates/Reference-Template.md
+++ b/TSG/Templates/Reference-Template.md
@@ -130,7 +130,7 @@ Verify these values against current public Microsoft documentation and the produ
 | Product or component | Supported versions | Supported scenarios | Unsupported scenarios | Source of truth |
 | -------------------- | ------------------ | ------------------- | --------------------- | --------------- |
 | {Azure Local product or component} | {Version or build range} | {Where this applies} | {Where this does not apply} | {Public Microsoft Learn URL or product documentation} |
-| {OEM, hardware, driver, firmware, or module when applicable} | {Version or model range} | {Supported use} | {Unsupported use} | {Public Microsoft Learn URL or OEM public documentation when permitted} |
+| {OEM, hardware, driver, firmware, or module when applicable} | {Version or model range} | {Supported use} | {Unsupported use} | {Public Microsoft Learn URL} |
 
 ## Required inputs
 

--- a/TSG/Templates/Reference-Template.md
+++ b/TSG/Templates/Reference-Template.md
@@ -1,19 +1,42 @@
+<!-- tsg-metadata
+{
+  "schema": "azure-local-supportability/tsg-metadata/v1",
+  "document_type": "reference",
+  "products": ["replace-me"],
+  "detector": {
+    "type": "none",
+    "signal": null
+  },
+  "validation": {
+    "fidelity_level": "L0",
+    "technical_grade": null,
+    "reproduction_substrate": "none",
+    "automation_status": "not-assessed",
+    "last_validated": null,
+    "spec_ref": ""
+  }
+}
+-->
+
 <!--
 Reference Template
-- Focus on providing configuration guidance, technical specifications, and examples
-- Reference documents help readers understand what needs to be configured and what's possible
-- Replace all {placeholders} with relevant content
-- This template provides a suggested structure - adapt it to make sense for your specific content
-    - The goal is clarity and usability for the reader
 
-Styling
-- Images should be placed in the `./images` folder and referenced
-- Any code block or JSON should be wrapped in triple backticks (```) with language identifier
-- References to Azure Local public documentation should always direct to the latest version
-- Use tables for specifications, requirements, and comparisons
-- Use code blocks for configuration examples
+Purpose:
+- Use this template for configuration references, supported settings, technical specifications, option comparisons, and examples.
+- Do not force troubleshooting-only sections into a reference. Use a troubleshooting template instead when the article is about symptoms, contributing factors, mitigation, or where a failure appears.
+- Replace all {placeholders} before publishing. Search for placeholders with this regex: \{([^}]+)\}
 
-You can use this regex to find placeholders that need to be replaced (search by Regex in your editor): \{([^}]+)\}
+Style and publishing rules:
+- No emojis, em dashes, or double-hyphen clause separators in prose.
+- External links must point to public Microsoft documentation. Prefer latest-version Microsoft Learn URLs without version query strings.
+- Images must be placed in an images folder next to the article and referenced with relative links.
+- Wrap command, JSON, and output examples in fenced code blocks with a language identifier.
+- Use tables for settings, defaults, requirements, constraints, and option comparisons.
+- Keep this article type focused on reference content. Do not add mandatory Severity, Symptoms, Root Cause, or Where this failure appears sections.
+
+Metadata marker:
+- Keep exactly one tsg-metadata HTML comment in each generated article.
+- Before publishing, replace products. If you select a detector, update detector.type and detector.signal together, then update validation fields if TSG-FORGE validation has run.
 -->
 
 # {Title}
@@ -28,144 +51,371 @@ You can use this regex to find placeholders that need to be replaced (search by 
     <td><strong>{Topic Name}</strong>: {Brief description of what this reference covers}</td>
   </tr>
   <tr>
+    <th style="text-align:left; width: 180px;">Document type</th>
+    <td><strong>Reference</strong></td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 180px;">Audience</th>
+    <td>{Primary reader, owner, and handoff audience, such as Microsoft Customer Support Services (CSS) or a systems integrator (SI)}</td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 180px;">Applicable products</th>
+    <td>{Azure Local product, component, OEM, or feature family}</td>
+  </tr>
+  <tr>
+    <th style="text-align:left; width: 180px;">Supported versions</th>
+    <td>{Supported Azure Local release, build, or version range}</td>
+  </tr>
+  <tr>
     <th style="text-align:left; width: 180px;">Scope</th>
-    <td>{Brief description of what configurations, scenarios, or deployment patterns this covers}</td>
+    <td>{Brief description of configurations, scenarios, or deployment patterns this covers}</td>
   </tr>
 </table>
 
 ## Overview
 
-{Brief description of what this reference document provides - configurations, specifications, examples, etc.}
+{Brief description of what this reference document provides: configurations, specifications, defaults, constraints, examples, validation methods, and why the safest default matters.}
+
+## At-a-glance applicability
+
+Use this summary so readers can decide whether this reference applies before copying a setting or command.
+
+**Fast-path decision card:** Fill in these three lines near the top of every generated reference so leaders and field engineers can make a quick go or no-go decision.
+
+| Decision line | Required content |
+| ------------- | ---------------- |
+| Applies | {Yes, no, or conditional. Name the exact product, supported versions, deployment phase, and scale where this reference applies.} |
+| Safe to proceed | {Yes, no, or conditional. State whether every placeholder has been replaced, every source has been verified, and the pre-check is passing.} |
+| Next owner if blocked | {Customer IT, partner or systems integrator (SI), Microsoft Customer Support Services (CSS), networking, storage, security, update, OEM, or product group, plus the evidence to attach.} |
+
+| Field | Required content |
+| ----- | ---------------- |
+| Audience | {Who should read this: IT admin, Microsoft Customer Support Services (CSS) engineer, partner deployment engineer, OEM engineer, or other role} |
+| Owner or lane | {Customer IT, partner or systems integrator (SI), Microsoft Customer Support Services (CSS), OEM, networking, storage, security, update, or product group owner} |
+| Applicable products | {Explicit Azure Local product or component names. Replace the metadata marker products array too.} |
+| Supported versions | {Release, build, firmware, driver, or module versions where this reference applies} |
+| Deployment phase | {Deployment, add node, update, upgrade, steady state, disconnected operation, or other phase} |
+| Scale of application | {Per node, per cluster, per site, across a fleet, or not applicable} |
+| Environment assumptions | {Connected or disconnected mode, hardware class, OEM, region, domain, network, or subscription assumptions} |
+| Customer impact | {What reader decision or operational outcome this reference supports} |
+| Expected decision time | {Estimated time to decide applicability, or why timing is not applicable} |
+| Maintenance-window length | {Expected maintenance-window length, or why no window is required} |
+| Downtime or workload risk | {None, read-only, maintenance window required, workload impact possible, or not applicable} |
+| Workload-impact checklist | {State whether the guidance can involve VM movement, drain, reboot, live migration, or application-availability risk} |
+| Handoff trigger and evidence | {When networking, OEM, Microsoft Customer Support Services (CSS), partner, or product group owns the next step, and the exact logs, command output, firmware data, or screenshots to attach} |
+| Fastest validation | {The shortest safe command or check that proves the configured state} |
 
 ## Scope
 
-### In Scope
+### In scope
 
-{What configurations, scenarios, or deployment patterns this reference covers}
+{What configurations, settings, examples, or deployment patterns this reference covers.}
 
 - {Configuration type 1}
 - {Scenario 1}
 - {Deployment pattern 1}
 
-### Out of Scope
+### Out of scope
 
-{What is not covered by this reference - helps set expectations}
+{What is not covered by this reference. Include explicit unsupported products, versions, deployment phases, or ownership lanes.}
 
 - {Configuration type not covered}
 - {Scenario not applicable}
+- {Product, version, or OEM model not supported by this reference}
+
+## Applicable products and supported versions
+
+Verify these values against current public Microsoft documentation and the product source of truth before publishing.
+
+| Product or component | Supported versions | Supported scenarios | Unsupported scenarios | Source of truth |
+| -------------------- | ------------------ | ------------------- | --------------------- | --------------- |
+| {Azure Local product or component} | {Version or build range} | {Where this applies} | {Where this does not apply} | {Public Microsoft Learn URL or product documentation} |
+| {OEM, hardware, driver, firmware, or module when applicable} | {Version or model range} | {Supported use} | {Unsupported use} | {Public Microsoft Learn URL or OEM public documentation when permitted} |
+
+## Required inputs
+
+List every value the reader must collect before using the reference. Define each value in plain language and provide a safe example.
+
+Do not run any example until every `{placeholder}` has been replaced with an environment-specific value and the source for that value has been verified. Brace placeholders are authoring markers, not runnable command text.
+
+| Input | Plain-language definition | Example value | Required or optional | How to find it | Notes |
+| ----- | ------------------------- | ------------- | -------------------- | -------------- | ----- |
+| {Input name} | {What this value means} | {Example} | {Required or optional} | {Command, portal location, or document} | {Constraints or cautions} |
+| {Input name} | {What this value means} | {Example} | {Required or optional} | {Command, portal location, or document} | {Constraints or cautions} |
+
+Add a short glossary for terms that a first-time Azure Local reader may not know.
+
+| Term | Definition | Why it matters here |
+| ---- | ---------- | ------------------- |
+| {Term 1} | {Plain-language definition} | {How misunderstanding this term could lead to the wrong setting or owner} |
+| {Term 2} | {Plain-language definition} | {How this term affects validation or handoff} |
 
 ## Requirements
 
-{Technical requirements, prerequisites, or constraints that apply to the configurations in this reference}
+{Technical requirements, prerequisites, permissions, dependencies, or constraints that apply to the configurations in this reference.}
 
-| Requirement     | Specification   | Notes                |
-| --------------- | --------------- | -------------------- |
-| {Requirement 1} | {Specification} | {Additional context} |
-| {Requirement 2} | {Specification} | {Additional context} |
+| Requirement | Specification | Required privilege | Notes |
+| ----------- | ------------- | ------------------ | ----- |
+| {Requirement 1} | {Specification} | {None, local admin, Azure role, OEM access, or other privilege} | {Additional context} |
+| {Requirement 2} | {Specification} | {None, local admin, Azure role, OEM access, or other privilege} | {Additional context} |
 
-## Table of Contents
+## Table of contents
 
-{Update Table of Contents as needed - organize sections to best serve your readers}
+Update this table of contents if you rename, add, or remove sections.
 
 - [Overview](#overview)
+- [At-a-glance applicability](#at-a-glance-applicability)
 - [Scope](#scope)
+- [Applicable products and supported versions](#applicable-products-and-supported-versions)
+- [Required inputs](#required-inputs)
 - [Requirements](#requirements)
-- [Configuration Reference](#configuration-reference)
+- [Configuration reference](#configuration-reference)
+- [Action pattern for generated examples](#action-pattern-for-generated-examples)
 - [Examples](#examples)
 - [Validation](#validation)
+- [Configuration comparison](#configuration-comparison)
+- [Future automation metadata](#future-automation-metadata)
+- [Related documentation](#related-documentation)
 
-## Configuration Reference
+## Configuration reference
 
-{Main configuration content - adapt structure based on your topic}
+{Main configuration content. Organize by setting family, option, API, registry value, policy, resource type, or deployment pattern.}
 
-### {Configuration Area 1}
+### {Configuration area 1}
 
-{Description of this configuration area and when it's used}
+{Description of this configuration area, when it is used, and why the recommended default is safe.}
 
-#### {Sub-configuration or Option 1}
+#### Settings and defaults
 
-{Explanation of this specific configuration}
+| Setting or parameter | Purpose | Default value | Default source | Allowed values or range | Required or optional | Constraints and edge cases | Security implications |
+| -------------------- | ------- | ------------- | -------------- | ----------------------- | -------------------- | -------------------------- | --------------------- |
+| `{parameter1}` | {Description and purpose} | {Default value or not applicable} | {Source of truth} | {Allowed values} | {Required or optional} | {Constraints, unsupported values, or side effects} | {Identity, Role-Based Access Control (RBAC), certificate, firewall, or secret exposure considerations} |
+| `{parameter2}` | {Description and purpose} | {Default value or not applicable} | {Source of truth} | {Allowed values} | {Required or optional} | {Constraints, unsupported values, or side effects} | {Security implications, or Not applicable} |
+
+#### Action or configuration example
+
+Classify the action type first. Use [READ-ONLY] for non-mutating inspection or validation. If the action changes or could change state, choose one canonical risk label: [LOW RISK] for low-impact state changes, [MEDIUM RISK] for reversible configuration changes that may affect availability or operations, and [HIGH RISK] for privileged, broad, hard-to-rollback, or workload-impacting changes.
+
+| Field | Required content |
+| ----- | ---------------- |
+| Action type | {[READ-ONLY] for non-mutating actions, otherwise state-changing} |
+| Risk label | {Not applicable for read-only action type, otherwise [LOW RISK], [MEDIUM RISK], or [HIGH RISK]} |
+| Privilege required | {None, local administrator, Azure role, OEM access, or other privilege} |
+| State-changing | {Yes or no} |
+| Workload impact | {Expected VM, cluster, network, storage, update, security, drain, reboot, live migration, or application-availability impact} |
+| Maintenance window | {Required, recommended, or not required} |
+| Pre-check | {Command or inspection that proves it is safe to proceed} |
+| Action | {Command, portal action, or configuration update} |
+| Expected result or output | {Exact success shape, expected output, expected state, and accepted variance} |
+| Stop condition | {Condition that tells the reader to stop and escalate before changing more state} |
+| Handoff trigger | {Which owner takes over if the stop condition is met, and what evidence to attach} |
+| Rollback | {How to restore the previous state, or why rollback is not applicable} |
+| Expected rollback output | {Output or state that proves rollback ran successfully} |
+| Rollback verification | {Independent check that proves the previous or safe state is restored} |
+| Escalation | {Owner, support path, and evidence package if rollback or verification fails} |
+| Verification | {How to prove the final state matches this reference} |
+
+**Pre-check command:**
 
 ```console
-# Configuration example with comments
-{configuration commands}
+{read-only pre-check command}
 ```
 
-**Key Parameters:**
+**Action command or portal action summary:**
 
-- `{parameter1}`: {Description and purpose}
-- `{parameter2}`: {Description and purpose}
+```console
+{configuration command or portal action summary}
+```
 
-#### {Sub-configuration or Option 2}
+**Verification command:**
 
-{Explanation of alternative or additional configuration}
+```console
+{validation command}
+```
 
-### {Configuration Area 2}
+**Expected output:**
 
-{Description of another configuration area}
+```console
+{Expected command output, status, or state. Include the failure output shape when it changes the next step.}
+```
+
+#### {Sub-configuration or option 2}
+
+{Explanation of an alternative option, including why a reader would choose it and how its constraints differ from the default.}
+
+### {Configuration area 2}
+
+{Description of another configuration area, including ownership lane, defaults, constraints, and validation.}
+
+## Action pattern for generated examples
+
+Every generated action pattern must include all rows below. If a row does not apply, write `Not applicable` and explain why.
+
+| Pattern element | Author prompt |
+| --------------- | ------------- |
+| Action type | {[READ-ONLY] for non-mutating actions, otherwise state-changing} |
+| Risk label | {Not applicable for read-only action type, otherwise [LOW RISK], [MEDIUM RISK], or [HIGH RISK]} |
+| Privilege required | {None, local administrator, Azure role, OEM access, or other privilege} |
+| Workload impact | {Expected VM, cluster, network, storage, update, security, drain, reboot, live migration, or application-availability impact} |
+| Maintenance window or approval gate | {Required, recommended, not required, or not applicable, plus the approval owner when required} |
+| Pre-check | {What confirms the current state and proves it is safe to continue?} |
+| Action | {What exact command, portal operation, file edit, or configuration change should the reader perform?} |
+| Expected result or output | {What exact output or state should appear after the action?} |
+| Stop condition | {What error, missing prerequisite, unexpected state, or risk should make the reader stop?} |
+| Rollback | {How does the reader return to the prior state if the action fails or is no longer wanted?} |
+| Expected rollback output | {What output or state proves the rollback command succeeded?} |
+| Rollback verification | {What independent check proves rollback restored the previous or safe state?} |
+| Escalation owner and evidence | {Who owns the next step if stopped or rollback fails, and what evidence must be attached?} |
+| Verification | {What final check proves the reference guidance was applied correctly?} |
 
 ## Examples
 
-{Real-world configuration examples that demonstrate the concepts}
+{Real-world Azure Local configuration examples that demonstrate the concepts. Each example should be safe to copy after the reader replaces placeholders.}
 
-### {Example Scenario 1}
+### {Example scenario 1}
 
-{Description of the scenario this example addresses}
+{Description of the scenario this example addresses and why it is relevant to Azure Local.}
 
-**Environment:**
+**Environment assumptions:**
 
-- {Environment detail 1}
-- {Environment detail 2}
+- Applicable products: {Product or component}
+- Supported versions: {Version or build range}
+- Ownership lane: {Customer IT, partner, Microsoft Customer Support Services (CSS), OEM, or product group}
+- Scale of application: {Per node, per cluster, per site, across a fleet, or not applicable}
+- Workload impact: {None, possible, expected, or unknown. Call out VM movement, drain, reboot, live migration, and application-availability risk when relevant.}
+- Required privileges: {Privilege required}
+
+**Variables:**
+
+| Variable | Example | Notes |
+| -------- | ------- | ----- |
+| `{variable1}` | `{example-value}` | {Meaning and constraints} |
+| `{variable2}` | `{example-value}` | {Meaning and constraints} |
 
 **Configuration:**
+
+| Field | Value |
+| ----- | ----- |
+| Action type | {[READ-ONLY] for non-mutating examples, otherwise state-changing} |
+| Risk label | {Not applicable for read-only action type, otherwise [LOW RISK], [MEDIUM RISK], or [HIGH RISK]} |
+| Pre-check | {Pre-check command or inspection} |
+| Action | {Configuration command or portal action} |
+| Expected result or output | {Exact expected result} |
+| Stop condition | {When to stop} |
+| Handoff trigger | {Next owner and evidence package if blocked} |
+| Rollback | {Rollback command or manual recovery} |
+| Expected rollback output | {Output or state that proves rollback succeeded} |
+| Rollback verification | {Independent check that proves rollback restored the previous or safe state} |
+| Escalation | {Owner and evidence package if rollback or verification fails} |
+| Verification | {Validation command or method} |
 
 ```console
 {Complete configuration example}
 ```
 
-### {Example Scenario 2}
+**Expected output:**
 
-{Description of another scenario}
+```console
+{Expected output or final state}
+```
+
+### {Example scenario 2}
+
+{Description of another scenario, including what differs from the default, what constraints apply, and how to validate it.}
 
 ## Validation
 
-{Methods to verify that configurations are working correctly}
+{Methods to verify that configurations are working correctly. Include the evidence a support engineer, partner, or automation system should collect.}
 
-### {Validation Method 1}
+### {Validation method 1}
 
-{Description of what this validates}
+{Description of what this validates and which setting or example it covers.}
+
+| Field | Required content |
+| ----- | ---------------- |
+| Action type | {[READ-ONLY] for non-mutating validation, otherwise state-changing} |
+| Risk label | {Not applicable for read-only action type, otherwise [LOW RISK], [MEDIUM RISK], or [HIGH RISK]} |
+| Privilege required | {None, local administrator, Azure role, OEM access, or other privilege} |
+| Workload impact | {Expected VM, cluster, network, storage, update, security, drain, reboot, live migration, or application-availability impact} |
+| Maintenance window or approval gate | {Required, recommended, not required, or not applicable, plus the approval owner when required} |
+| Pre-check | {Read-only state check before validation} |
+| Validation action | {Command, portal check, API call, or inspection} |
+| Expected output | {Exact passing output or state} |
+| Failure output | {Common failing output or unexpected state} |
+| Accepted variance | {Values that can differ without changing the conclusion} |
+| Stop condition | {When to stop and collect evidence} |
+| Rollback | {Rollback if validation requires a state-changing probe, otherwise Not applicable} |
+| Expected rollback output | {Output or state that proves rollback succeeded, or Not applicable} |
+| Rollback verification | {Independent check that proves rollback restored the previous or safe state, or Not applicable} |
+| Escalation | {Owner and evidence package if validation, rollback, or rollback verification fails} |
+| Verification | {Final proof that the intended configuration is active} |
+| Evidence to collect | {Logs, command output, screenshots, or exported data} |
 
 ```console
-# Validation command
+Validation command:
 {command to run}
 ```
 
-**Expected Output:**
+**Expected output:**
 
 ```console
 {sample of expected output}
 ```
 
-### {Validation Method 2}
+### {Validation method 2}
 
-{Another validation approach}
+{Another validation approach. Include pass criteria, fail criteria, and what the reader should collect if validation fails.}
 
-## Configuration Comparison
+## Configuration comparison
 
-{Optional section - use when comparing different configuration options}
+{Optional section. Use this when comparing configuration options, defaults, supported versions, or deployment patterns.}
 
-| Feature     | {Option 1}    | {Option 2}    | {Option 3}    |
-| ----------- | ------------- | ------------- | ------------- |
-| {Feature 1} | {Value}       | {Value}       | {Value}       |
-| {Feature 2} | {Value}       | {Value}       | {Value}       |
-| {Use Case}  | {When to use} | {When to use} | {When to use} |
+| Feature | {Option 1} | {Option 2} | {Option 3} |
+| ------- | ---------- | ---------- | ---------- |
+| Default | {Value and source} | {Value and source} | {Value and source} |
+| Constraints | {Constraints} | {Constraints} | {Constraints} |
+| Supported versions | {Versions} | {Versions} | {Versions} |
+| Use case | {When to use} | {When to use} | {When to use} |
+| Action type | {[READ-ONLY] or state-changing} | {[READ-ONLY] or state-changing} | {[READ-ONLY] or state-changing} |
+| State-changing risk label | {Not applicable, [LOW RISK], [MEDIUM RISK], or [HIGH RISK]} | {Not applicable, [LOW RISK], [MEDIUM RISK], or [HIGH RISK]} | {Not applicable, [LOW RISK], [MEDIUM RISK], or [HIGH RISK]} |
+| Validation | {How to validate} | {How to validate} | {How to validate} |
 
-## Related Documentation
+## Future automation metadata
 
-{Links to related documents, official documentation, and additional resources}
+Keep the `tsg-metadata` marker at the top of the generated article. Validate it against the [metadata JSON Schema](../Templates/tsg-metadata.schema.json) before publishing, then update these fields so future tooling can route, validate, and automate the reference without changing the article type.
 
-- [{Related document 1}](link) - Brief description
-- [{Related document 2}](link) - Brief description
-- [{Official documentation}](link) - Brief description
+The schema link above is correct after copying this template to a component root folder, for example `TSG/Storage/Reference-Example.md`. If the article is copied into a nested topic folder, add one `../` for each extra folder level, for example `../../Templates/tsg-metadata.schema.json` from `TSG/Storage/Topic/Reference-Example.md`.
 
----
+| Metadata field | Required value |
+| -------------- | -------------- |
+| `schema` | `azure-local-supportability/tsg-metadata/v1` |
+| `document_type` | `reference` |
+| `products` | {Replace `replace-me` with explicit applicable products} |
+| `detector.type` | `none` unless this reference has an automation detector |
+| `detector.signal` | Use JSON `null` when `detector.type` is `none`; when selecting a detector, set `detector.type` and `detector.signal` together. |
+| `validation.fidelity_level` | `L0` until live or static validation proves a higher fidelity level |
+| `validation.technical_grade` | JSON `null` until TSG-FORGE produces authoritative grade `A`, `B`, `C`, or `F` with report or spec evidence |
+| `validation.reproduction_substrate` | `none` unless validation requires `vm`, `hardware`, or `either` |
+| `validation.automation_status` | `not-assessed`, `scaffold`, `ready`, `proven`, `blocked`, or `manual` |
+| `validation.last_validated` | `null` or a date in `YYYY-MM-DD` format |
+| `validation.spec_ref` | {Path to the validation spec, or an empty string} |
+
+Use the definitions below when completing metadata. Keep execution surface separate from automation status: execution surface describes where a consumer runs the guidance, such as on-device, cloud, or mixed. Automation status describes how ready the automation is.
+
+| Vocabulary | Values and meaning |
+| ---------- | ------------------ |
+| Fidelity level | `L0`: static lint and persona review only. `L1`: read-only commands or checks were validated. `L2`: faithful proxy or data-source validation was exercised. `L3`: scratch-object or isolated reproduction was exercised. `L4`: full inject, detect, mitigate, and revalidate loop was proven. |
+| Technical grade | `validation.technical_grade` is the authoritative technical grade. Use JSON `null` until TSG-FORGE produces `A`, `B`, `C`, or `F` with report or spec evidence. |
+| Reproduction substrate | `none`: no live substrate. `vm`: disposable virtual or nested environment. `hardware`: physical lab hardware. `either`: either VM or hardware can reproduce the validation. |
+| Automation status | `not-assessed`: no automation assessment yet. `scaffold`: metadata or helpers exist but are incomplete. `ready`: automation is designed and ready to run. `proven`: automation has been validated and has evidence. `blocked`: automation cannot proceed until a dependency is removed. `manual`: human validation is required. |
+| Detector type and signal | Allowed detector types are `command`, `control-plane`, `envchecker`, `eventlog`, `feature`, `manual`, `none`, `portal`, `registry`, `service`, and `telemetry`. `none` with `signal` set to JSON `null` means no detector. If the article uses a detector, choose the detector type and set `signal` to the command, event, telemetry table, portal location, or other observable signal together. |
+| Execution surface | This is separate from `validation.automation_status`. Use `on-device`, `mixed`, `cloud-diagnostic`, `cloud-control`, or `thin`. `thin` means prose-only reference content with no executable diagnostic or action. |
+| Admin surface state, if used | Use `shown`, `not-evident`, or `absent`. `not-evident` means the surface was checked and the issue is not expected there. `absent` means the surface is uncharacterized and is not publish-ready. |
+
+## Related documentation
+
+Use only public Microsoft links for external references. Prefer latest-version Microsoft Learn URLs and do not include release-specific query strings. Use repo-relative links only for other public files in this repository.
+
+- [{Azure Local documentation}](https://learn.microsoft.com/azure/azure-local/) - Public Azure Local documentation
+- [{Related public Microsoft document}](https://learn.microsoft.com/azure/azure-local/) - Brief description
+- [{Related public Microsoft document}](https://learn.microsoft.com/azure/azure-local/) - Brief description

--- a/TSG/Templates/Troubleshoot-Template.md
+++ b/TSG/Templates/Troubleshoot-Template.md
@@ -1,108 +1,302 @@
-<!--
-Troubleshoot Template
-- Focus on providing systematic troubleshooting guidance for specific issues
-- Replace all {placeholders} with relevant content
-- This template provides a suggested structure - adapt sections as needed for your specific issue
-- Skip optional sections if they don't add value
-
-Styling
-- Images should be placed in the `./images` folder and referenced
-- Any code block should be wrapped in triple backticks (```) with language identifier
-- Use numbered lists for sequential steps and bullet points for symptoms/options
-
-Coding Standards
-- All code snippets MUST be safe to execute in a production environment
-- Check that the environment is in the expected state before performing mitigation
-
-You can use this regex to find placeholders that need to be replaced (search by Regex in your editor): \{([^}]+)\}
+<!-- tsg-metadata
+{
+  "schema": "azure-local-supportability/tsg-metadata/v1",
+  "document_type": "troubleshoot",
+  "products": ["replace-me"],
+  "detector": {
+    "type": "none",
+    "signal": null
+  },
+  "validation": {
+    "fidelity_level": "L0",
+    "technical_grade": null,
+    "reproduction_substrate": "none",
+    "automation_status": "not-assessed",
+    "last_validated": null,
+    "spec_ref": ""
+  }
+}
 -->
 
-# {Issue Title}
+# {Issue title}
 
-<table border="1" cellpadding="6" cellspacing="0" style="border-collapse:collapse; margin-bottom:1em;">
-  <tr>
-    <th style="text-align:left; width: 180px;">Component</th>
-    <td><strong>{Component Name}</strong></td>
-  </tr>
-  <tr>
-    <th style="text-align:left; width: 180px;">Severity</th>
-    <td><strong>{Critical/High/Medium/Low}</strong></td>
-  </tr>
-  <tr>
-    <th style="text-align:left;">Applicable Scenarios</th>
-    <td><strong>{Deployment/Update/AddNode/etc.}</strong></td>
-  </tr>
-  <tr>
-    <th style="text-align:left;">Affected Versions</th>
-    <td><strong>{Version ranges or "All versions"}</strong></td>
-  </tr>
-</table>
+Use this template for Azure Local troubleshooting guides. Replace all placeholders in braces before publishing. Keep all actions production-safe, use public Microsoft links only, and test every command example.
 
-## Overview
+## Table of contents
 
-{Brief description of the issue, what causes it, and when it typically occurs}
+- [Article metadata](#article-metadata)
+- [Executive triage summary](#executive-triage-summary)
+- [Symptoms and scope](#symptoms-and-scope)
+- [Terms to define before publishing](#terms-to-define-before-publishing)
+- [Where this appears](#where-this-appears)
+- [Preconditions and stop gates](#preconditions-and-stop-gates)
+- [Diagnosis](#diagnosis)
+- [Contributing factors and evidence](#contributing-factors-and-evidence)
+- [Mitigation](#mitigation)
+- [Rollback](#rollback)
+- [Verification](#verification)
+- [Escalation and evidence package](#escalation-and-evidence-package)
+- [Prevention and monitoring](#prevention-and-monitoring)
+- [Future test automation metadata](#future-test-automation-metadata)
+- [Related documentation](#related-documentation)
 
-## Symptoms
+## Article metadata
 
-{What users will see when encountering this issue}
+| Field | Value |
+| --- | --- |
+| Component | {Component name} |
+| Applicable products | {Azure Local products, services, or features that this guide applies to} |
+| Supported versions | {Supported Azure Local releases, OS builds, solution versions, or Solution Builder Extension (SBE) versions} |
+| Audience | {Primary reader, such as customer IT admin, Microsoft Customer Support Services (CSS) engineer, OEM field engineer, partner or systems integrator (SI) deployment engineer, or workload owner} |
+| Applicable scenarios | {Deployment, update, add node, upgrade, steady state, or workload operation} |
+| Severity | {Critical, high, medium, or low, with a short rationale} |
+| Customer impact | {VM impact, update blocked, deployment blocked, degraded redundancy, monitoring only, or none} |
+| Primary owner | {Customer IT, Microsoft Customer Support Services (CSS), product group, OEM, partner, or systems integrator (SI)} |
+| Execution surface | {on-device, mixed, cloud-diagnostic, cloud-control, or thin} |
+| Risk summary | {Highest expected mitigation risk and whether a maintenance window is needed} |
+
+## Executive triage summary
+
+| Question | Answer |
+| --- | --- |
+| What is broken? | {One sentence symptom summary} |
+| Who should act? | {Role or team that should run the guide} |
+| Fastest safe next action | {The first read-only check to run} |
+| Estimated duration | {Expected time to diagnose and mitigate} |
+| Downtime or workload risk | {None, possible, expected, or unknown, with reason} |
+| Escalate immediately if | {Condition that requires CSS, product group, OEM, or partner help} |
+
+## Symptoms and scope
+
+Describe exactly what the operator or customer sees. Include enough detail to distinguish this issue from similar storage, network, update, Arc, OEM, or workload issues.
+
+| Prompt | Details |
+| --- | --- |
+| Exact error text | {Paste the exact error, status code, Event ID, health fault, validator result, or portal message} |
+| First observed time | {UTC timestamp or approximate time window} |
+| Affected resources | {Cluster, node names, volumes, adapters, VMs, Arc Resource Bridge, AKS clusters, or update run} |
+| Customer or workload impact | {What workloads, VMs, deployment steps, or update steps are affected} |
+| Recent changes | {Updates, firmware changes, network changes, policy changes, node maintenance, or none known} |
+| Explicitly not affected | {Resources or operations checked and found healthy} |
 
 **Common error messages:**
-{Include specific error messages users might see}
 
-```
+```text
 {Error message example}
 ```
 
 **Observable behaviors:**
 
-- {Symptom 1}
-- {Symptom 2}
+- {Symptom 1 with affected surface and timestamp}
+- {Symptom 2 with affected surface and timestamp}
+- {Symptom 3, if applicable}
 
-## Root Cause
+## Terms to define before publishing
 
-{Why this issue occurs}
+Define acronyms, Azure Local objects, command names, and component names that a first-time reader must understand before following the guide. Keep definitions short and action-oriented.
 
-## Resolution
+| Term | Plain-language definition | Why the reader needs it |
+| --- | --- | --- |
+| {Acronym or product object} | {Short definition using customer-facing language} | {Decision, command, or safety gate that depends on this term} |
+| {Safety term, such as quorum, detached virtual disk, or degraded redundancy} | {What the state means and how to recognize it} | {Why it changes the stop condition, risk label, or rollback path} |
+| {Cmdlet, portal blade, Event ID, or log name} | {What it is and where the reader sees it} | {How it is used in diagnosis, mitigation, rollback, or verification} |
 
-### Prerequisites
+## Where this appears
 
-{Any requirements before starting - skip if none}
+For each surface, record whether the issue is `shown`, `not-evident`, or `absent`. `absent` means the surface has not been characterized yet and is not publish-ready. Do not use `not checked` in a final article. Keep Windows Admin Center (standalone host) separate from Windows Admin Center in Azure, which means Windows Admin Center in the Azure portal. The final row covers component or tool log files on disk.
 
-- {Prerequisite 1}
-- {Prerequisite 2}
+| State | Evidence bar |
+| --- | --- |
+| shown | The surface displays the issue now. Include the exact command, blade, log, Event ID, path, timestamp, or output. |
+| not-evident | The surface was checked for the relevant time window, but no matching signal was found or the issue is not expected there. Include what was checked, the time window or freshness proof, and why that surface is not useful. |
+| absent | The surface has not been characterized yet. Treat this as a draft work item, not a publish-ready value. |
 
-### Steps
+| Admin surface | Status | Evidence to capture |
+| --- | --- | --- |
+| PowerShell on an Azure Local node | {shown, not-evident, or absent} | {Cmdlet name, command output, health fault, validator result, or reason it is not-evident} |
+| Azure portal | {shown, not-evident, or absent} | {Azure Local, Arc, Updates, Resource Health, or other blade and the visible status} |
+| Windows event logs | {shown, not-evident, or absent} | {Log name, provider, Event ID, level, timestamp, and message excerpt} |
+| Cluster logs using Get-ClusterLog | {shown, not-evident, or absent} | {Cluster log channel, timestamp, resource, or reason it is not-evident} |
+| Windows Failover Cluster Manager | {shown, not-evident, or absent} | {Failed role, resource, node, network, storage object, or reason it is not-evident} |
+| Windows Admin Center (standalone host) | {shown, not-evident, or absent} | {Tool page, status, alert, or reason it is not-evident} |
+| Windows Admin Center in the Azure portal | {shown, not-evident, or absent} | {Tool page, status, alert, or reason it is not-evident} |
+| Component / tool log files (on disk) | {shown, not-evident, or absent} | {Component or tool log files path, on-disk log path, .AzStackHci report, diagnostic log file, timestamp, and message excerpt} |
 
-1. **{Action}**
-   {action description, what are we doing, and why?}
+## Preconditions and stop gates
 
-   ```powershell
-   # Verify current state first
-   {Verification command}
+Complete these checks before any mitigation. If a stop condition is met, do not continue with state-changing steps until the condition is resolved or the case is escalated.
 
-   # Perform fix
-   {Fix command}
-   ```
+| Gate | Pre-check | Expected result or output | Stop condition | Owner |
+| --- | --- | --- | --- | --- |
+| Permissions | {Command or portal check for required role or local admin rights} | {Required role or privilege is present} | {Required privilege is missing} | {Customer IT, Microsoft CSS, OEM, partner, or product group} |
+| Workload safety | {Check VM state, owner node, redundancy, or maintenance window} | {Workloads can tolerate the action or are drained} | {Critical workload cannot be moved or protected} | {Workload owner} |
+| Cluster health | {Read-only command to confirm quorum, node, storage, and network health} | {Cluster is stable enough for the action} | {Quorum risk, meaning not enough voting members to keep the cluster online; node down; detached virtual disk, meaning disconnected from storage; or degraded redundancy, meaning fewer healthy copies than policy requires} | {Cluster admin} |
+| Recovery material | {Check backups, BitLocker recovery keys, snapshots, or configuration export when applicable} | {Recovery material is available and current} | {Recovery material is missing for a risky action} | {Customer IT} |
+| OEM or firmware readiness | {Check model, firmware, BIOS, BMC, driver, or qualified configuration when applicable} | {Prerequisites are met or not applicable} | {OEM prerequisite is unmet or unclear} | {OEM or partner} |
 
-2. **{Next action}**
-   {action description, what are we doing, and why?}
+## Diagnosis
 
-   ```powershell
-   {Command}
-   ```
+Run diagnosis before mitigation. Prefer read-only commands. Each diagnosis branch must include expected healthy output, expected affected output, and the mitigation path it authorizes.
 
-3. **Verify resolution**
-   ```powershell
-   # Confirm fix worked
-   {Verification command}
-   ```
+| Step | Pre-check | Action | Expected healthy output | Expected affected output | Stop condition | Next branch |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | {Confirm the target resource and time window} | {Run read-only diagnostic command or portal check} | {Healthy output} | {Affected output} | {Output does not match this TSG, or target is wrong} | {Mitigation step, more diagnosis, or escalation} |
+| 2 | {Confirm the first result with an independent surface} | {Run second diagnostic command, log query, or portal check} | {Healthy output} | {Corroborating affected output} | {Contradictory evidence or stale data} | {Mitigation step, more diagnosis, or escalation} |
+| 3 | {Run the disproving check for the leading diagnosis} | {Command or check that would prove a different cause} | {No disproof found} | {Disproof found} | {Disproof found, do not run this mitigation} | {Alternate TSG or escalation} |
 
-## Prevention _(Optional)_
+```powershell
+# Example read-only diagnosis command. Replace with the exact command for this issue.
+{Read-only diagnosis command}
+```
 
-{How to prevent this issue from happening again - remove section if not applicable}
+## Contributing factors and evidence
 
-## Related Issues _(Optional)_
+Use blameless language. Do not assign human error or state a single root cause unless the evidence proves it. Every causal statement must cite the evidence that supports it.
 
-{Links to related TSGs or documentation - remove section if none}
+| Evidence label | Contributing factor or observation | Source | Why it matters |
+| --- | --- | --- | --- |
+| CONFIRMED | {Directly observed fact} | {Command, log, portal blade, table, file path, Event ID, or output value} | {Impact on the issue} |
+| INFERRED | {Reasoned conclusion from confirmed evidence} | {Specific confirmed facts used as the basis} | {Why the inference is justified} |
+| UNVERIFIABLE | {Claim that cannot be proven from available sources} | {Missing data, tool, log, access, or time window} | {Smallest next step to close the gap} |
 
----
+**Disproving check:** {Name the one command, log, or fact that would disprove the leading diagnosis. State whether it was checked.}
+
+## Mitigation
+
+Only run a mitigation after the matching diagnosis branch is satisfied and the preconditions are met. Use [READ-ONLY] for diagnostic or verification actions that do not change state; risk is not applicable because no state changes. Reserve the canonical risk labels for state-changing steps: [LOW RISK], [MEDIUM RISK], or [HIGH RISK].
+
+| Step | Action type or risk label | Privilege | Workload or maintenance gate | Pre-check | Action | Expected result or output | Stop condition | Rollback | Rollback verification | Escalation if blocked |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | [READ-ONLY] | {Required role or local right to read state} | {Risk not applicable because no state changes; no maintenance window required} | {Read-only check that confirms this step applies} | {Diagnostic or verification action that does not change state} | {Expected output} | {Condition that stops the step} | {Not applicable because no state changes} | {Not applicable because no state changes} | {Owner to contact if blocked} |
+| 2 | [MEDIUM RISK] | {Required role or local right} | {Maintenance window, workload drain, or owner approval required} | {Check workload, cluster, and permission prerequisites} | {State-changing command or portal action} | {Expected output} | {Condition that stops the step before or during execution} | {Command or procedure that restores the prior state} | {Expected rollback output and command or surface that confirms rollback} | {Owner to contact if blocked} |
+| 3 | [HIGH RISK] | {Required role or local right} | {Explicit maintenance window, recovery material, redundancy, and escalation approval required} | {Explicit maintenance window, recovery material, redundancy, and escalation approval check} | {High-risk action, if this TSG truly requires one} | {Expected output} | {Any unmet safety gate, unexpected output, or customer impact} | {Exact rollback or vendor-supported recovery path} | {Expected rollback output and post-rollback health validation} | {CSS, product group, OEM, partner, or SI escalation path} |
+
+```powershell
+# Pre-check
+{Pre-check command}
+
+# Action
+{Mitigation command}
+
+# Rollback, if the stop condition is met
+{Rollback command}
+
+# Rollback verification
+{Rollback verification command}
+
+# Verification
+{Verification command}
+```
+
+## Rollback
+
+Every state-changing mitigation step must have a rollback plan. If rollback is not possible, state that clearly, label the step [HIGH RISK], and require escalation before the action.
+
+| Mitigation step | Trigger to roll back | Rollback action | Expected rollback output | Verification after rollback |
+| --- | --- | --- | --- | --- |
+| {Step number or name} | {Unexpected result, customer impact, timeout, or operator decision} | {Rollback command or portal action} | {Expected output} | {Command, portal status, log, or workload check} |
+
+```powershell
+# Rollback example. Replace with the exact rollback for this issue.
+{Rollback command}
+```
+
+## Verification
+
+Verify both technical recovery and customer impact recovery. Include timing, because some surfaces update only after a scheduled health check or refresh.
+
+| Verification target | Command or surface | Expected success criteria | If it does not pass |
+| --- | --- | --- | --- |
+| Original detector | {Validator, cmdlet, Event ID, portal blade, or tool log} | {Bad signal is cleared or expected status is present} | {Repeat diagnosis, roll back, or escalate} |
+| Cluster health | {Cluster, storage, network, update, or Arc health command} | {Cluster is stable and no new critical health signal appeared} | {Stop and escalate with evidence package} |
+| Workloads | {VM, application, live migration, or customer validation check} | {Workloads are healthy or customer confirms recovery} | {Engage workload owner and preserve evidence} |
+| Admin surfaces | {Portal, Windows Admin Center, event logs, cluster logs, and component logs as applicable} | {Surfaces show healthy state or documented lag} | {Record lag or unresolved signal and continue diagnosis} |
+| Rollback readiness | {Check that rollback is still available or no longer needed} | {Rollback path remains available until success is confirmed} | {Do not close the case} |
+
+```powershell
+# Re-run the primary verification command.
+{Final verification command}
+```
+
+## Escalation and evidence package
+
+Escalate when diagnosis is inconclusive, a stop gate is met, mitigation risk is unacceptable, the issue recurs, or the guide points to a product group, OEM, partner, or Microsoft CSS owner.
+
+| Escalation target | Escalate when | Evidence to include |
+| --- | --- | --- |
+| Microsoft CSS | {Customer needs assisted support, diagnosis is inconclusive, or mitigation fails} | {Symptoms, timestamps, commands, outputs, logs, Event IDs, portal screenshots, and impact statement} |
+| Product group | {Confirmed product defect, unsupported state, repeated failure, or telemetry gap} | {CONFIRMED and INFERRED evidence, build versions, repro steps, and failed mitigation details} |
+| OEM vendor | {Firmware, driver, BIOS, BMC, model support, hardware fault, or qualified configuration issue} | {Model, serial or asset identifiers as appropriate, firmware and driver versions, logs, and hardware diagnostics} |
+| Partner or SI | {Deployment design, site-specific configuration, cabling, switch, identity, or policy ownership issue} | {Topology, configuration, change history, and exact failed step} |
+
+Before sharing externally, remove secrets, tokens, private keys, and unnecessary personal data.
+
+## Prevention and monitoring
+
+Use prevention guidance to reduce recurrence without blaming the person who operated the system.
+
+- {Monitoring or alert that detects recurrence}
+- {Pre-update, pre-deployment, or maintenance check that catches the issue early}
+- {Version, firmware, policy, or configuration guidance that reduces recurrence}
+- {Owner and cadence for review}
+
+## Future test automation metadata
+
+Complete this section so the TSG can be graded and improved by TSG-FORGE later. Keep the metadata marker aligned with the canonical [TSG metadata JSON Schema](../Templates/tsg-metadata.schema.json).
+
+| Field | Value |
+| --- | --- |
+| Detector type | {none, envchecker, eventlog, command, service, feature, registry, telemetry, manual, portal, or control-plane} |
+| Detector signal | {Cmdlet, Event ID, telemetry query, portal path, log path, or JSON null when Detector type is none} |
+| Inject strategy | {Reversible inject, proxy inject, scratch object, read-only validation, manual validation, or not safe to inject} |
+| Mitigation selector | {Marker, section, command, portal action, or manual procedure that identifies the mitigation block} |
+| Safety floor | {Minimum free space, quorum, redundancy, recovery material, or other floor that prevents harm} |
+| Rollback check | {Command or surface proving rollback restored prior state} |
+| Reproduction substrate | {vm, hardware, either, or none} |
+| Fidelity level | {L0, L1, L2, L3, or L4} |
+| Technical grade | {JSON null until TSG-FORGE produces A, B, C, or F from report or spec evidence} |
+| Automation status | {not-assessed, scaffold, ready, proven, blocked, or manual} |
+| Spec reference | {Path to companion spec, if one exists} |
+| Last validated | {JSON null until validation exists, then YYYY-MM-DD} |
+
+When `Detector type` is `none`, set `detector.signal` in the metadata marker to JSON `null`. When you select any other detector type, set both `detector.type` and `detector.signal` together. Set `validation.technical_grade` to JSON `null` until TSG-FORGE report or spec evidence produces A, B, C, or F.
+
+Execution surface and automation status are different fields. Execution surface describes where the article can run and must use on-device, mixed, cloud-diagnostic, cloud-control, or thin. Automation status describes the TSG-FORGE readiness of the test harness and must use not-assessed, scaffold, ready, proven, blocked, or manual.
+
+| Metadata value | Meaning |
+| --- | --- |
+| Detector `none` | No automated detector is defined yet. Use JSON `null` for `detector.signal`. |
+| Detector `envchecker` | Azure Local Environment Checker or readiness check output is the signal. |
+| Detector `eventlog` | A Windows event log, provider, and Event ID are the signal. |
+| Detector `command`, `service`, `feature`, or `registry` | A command result, service state, Windows feature state, or registry value is the signal. |
+| Detector `telemetry`, `manual`, `portal`, or `control-plane` | A fleet signal, human-observed state, portal blade, or Azure control-plane state is the signal. |
+| Execution surface `on-device` | The article can be executed by on-box commands on an Azure Local node. |
+| Execution surface `mixed` | The article combines on-device steps with connected portal, Azure control-plane, or cloud diagnostics. |
+| Execution surface `cloud-diagnostic` | The article depends on cloud or telemetry diagnostics and is not runnable only on the node. |
+| Execution surface `cloud-control` | The article changes or verifies Azure control-plane state, such as portal or ARM state. |
+| Execution surface `thin` | The article has context only and no executable diagnostic or mitigation path yet. |
+| Inject strategy `reversible inject` | The harness creates a real bad state and can restore the prior state automatically. |
+| Inject strategy `proxy inject` | The harness feeds controlled input to the real detector without causing the unsafe production failure. |
+| Inject strategy `scratch object` | The harness tests with an isolated temporary object, such as a test VM, test file, or scratch resource. |
+| Inject strategy `read-only validation` or `manual validation` | The harness validates diagnostics only, or a human must verify the state. |
+| Inject strategy `not safe to inject` | No safe or reversible inject exists for this issue. Validate diagnostics only and set automation_status to blocked or manual until a safe proof path exists. |
+| Fidelity `L0` | Static lint, metadata, and persona review only. |
+| Fidelity `L1` | Read-only diagnostic commands were validated. |
+| Fidelity `L2` | A safe proxy or synthetic data source exercised the detector or decision logic. |
+| Fidelity `L3` | An isolated scratch object exercised the failure and recovery path. |
+| Fidelity `L4` | Full live loop was proven: inject, detect, mitigate, revalidate, and clean up. |
+| Technical grade `null` | No TSG-FORGE technical grade has been produced yet. |
+| Technical grade `A`, `B`, `C`, or `F` | Authoritative technical grade from TSG-FORGE report or companion spec evidence. Do not invent a separate grade vocabulary. |
+| Automation `not-assessed` | No automation review has been performed. |
+| Automation `scaffold` | Metadata exists, but runnable automation is incomplete. |
+| Automation `ready` | Automation is ready to run but not yet proven. |
+| Automation `proven` | Automation has run and passed at the stated fidelity. |
+| Automation `blocked` | Automation is designed but blocked by safety, access, or substrate limits. |
+| Automation `manual` | The article intentionally requires human validation rather than automation. |
+
+## Related documentation
+
+Use public Microsoft links only. Do not include version-specific query strings in Microsoft Learn URLs.
+
+- {Public Microsoft documentation link}
+- {Related public Azure Local TSG link, if available}

--- a/TSG/Templates/Troubleshoot-Template.md
+++ b/TSG/Templates/Troubleshoot-Template.md
@@ -178,14 +178,18 @@ Only run a mitigation after the matching diagnosis branch is satisfied and the p
 # Action
 {Mitigation command}
 
-# Rollback, if the stop condition is met
+# Verification
+{Verification command}
+```
+
+Run the rollback block below **only** if a stop condition was met or the verification failed. Do not run it after a successful mitigation, or it will undo the change before final verification.
+
+```powershell
+# Rollback (run ONLY if a stop condition was met or the verification failed)
 {Rollback command}
 
 # Rollback verification
 {Rollback verification command}
-
-# Verification
-{Verification command}
 ```
 
 ## Rollback

--- a/TSG/Templates/tsg-metadata.schema.json
+++ b/TSG/Templates/tsg-metadata.schema.json
@@ -1,0 +1,218 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Azure/AzureLocal-Supportability/main/TSG/Templates/tsg-metadata.schema.json",
+  "title": "Azure Local Supportability TSG metadata",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "document_type",
+    "products",
+    "detector",
+    "validation"
+  ],
+  "properties": {
+    "schema": {
+      "const": "azure-local-supportability/tsg-metadata/v1"
+    },
+    "document_type": {
+      "description": "Public article template type.",
+      "enum": [
+        "deep-dive",
+        "how-to",
+        "overview",
+        "reference",
+        "troubleshoot"
+      ]
+    },
+    "products": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "detector": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "signal"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "none"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "signal": {
+                "type": "null"
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "signal": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      ],
+      "properties": {
+        "type": {
+          "description": "Detector implementation used to observe the issue.",
+          "enum": [
+            "command",
+            "control-plane",
+            "envchecker",
+            "eventlog",
+            "feature",
+            "manual",
+            "none",
+            "portal",
+            "registry",
+            "service",
+            "telemetry"
+          ]
+        },
+        "signal": {
+          "description": "Exact check, command, event, query, or manual surface. Use null only when detector.type is none.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "validation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "fidelity_level",
+        "technical_grade",
+        "reproduction_substrate",
+        "automation_status",
+        "last_validated",
+        "spec_ref"
+      ],
+      "properties": {
+        "fidelity_level": {
+          "description": "Validation depth from static review (L0) to a full live loop (L4).",
+          "enum": [
+            "L0",
+            "L1",
+            "L2",
+            "L3",
+            "L4"
+          ]
+        },
+        "technical_grade": {
+          "description": "TSG-FORGE technical grade, or null until graded.",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "enum": [
+                "A",
+                "B",
+                "C",
+                "F"
+              ]
+            }
+          ]
+        },
+        "reproduction_substrate": {
+          "description": "Lab substrate required to reproduce the validation.",
+          "enum": [
+            "either",
+            "hardware",
+            "none",
+            "vm"
+          ]
+        },
+        "automation_status": {
+          "description": "Lifecycle state of the validation automation.",
+          "enum": [
+            "blocked",
+            "manual",
+            "not-assessed",
+            "proven",
+            "ready",
+            "scaffold"
+          ]
+        },
+        "last_validated": {
+          "description": "ISO date of the latest qualifying validation, or null.",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "format": "date"
+            }
+          ]
+        },
+        "spec_ref": {
+          "description": "Internal TSG-FORGE specification or report reference.",
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "automation_status": {
+                "const": "proven"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "fidelity_level": {
+                "enum": [
+                  "L1",
+                  "L2",
+                  "L3",
+                  "L4"
+                ]
+              },
+              "technical_grade": {
+                "enum": [
+                  "A",
+                  "B",
+                  "C",
+                  "F"
+                ]
+              },
+              "reproduction_substrate": {
+                "enum": [
+                  "vm",
+                  "hardware",
+                  "either"
+                ]
+              },
+              "last_validated": {
+                "type": "string",
+                "format": "date"
+              },
+              "spec_ref": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Upgrade all eight public authoring templates with explicit applicability, safety, evidence, rollback, validation, escalation, and automation prompts.
- Add a canonical `azure-local-supportability/tsg-metadata/v1` JSON Schema.
- Separate read-only action classification from state-changing risk labels.
- Align component indexes, contribution guidance, and article metadata vocabulary.

## Validation

- TSG-FORGE static lint: A for all eight templates.
- Deterministic TSG PR lint: zero findings for all eight templates.
- Persona usability panel: 13 of 13 reviewers scored every template 5/5.
- Multi-model residual: two frontier model families per high-value lens, zero remaining findings. The third family was unavailable and is recorded as degraded coverage.
- All five article metadata markers validate against the canonical schema.
- Relative links and in-page anchors resolve at the template and documented copy locations.
- Live HaaS mutation: not applicable. These are L0 authoring assets, not executable fault scenarios.
